### PR TITLE
perf: cheaper callback bundle & multicall

### DIFF
--- a/src/BaseBundler.sol
+++ b/src/BaseBundler.sol
@@ -74,4 +74,14 @@ contract BaseBundler {
     function initiator() internal view returns (address) {
         return IHub(HUB).initiator();
     }
+
+    /// @notice Calls hub.multicallFromBundler with an already encoded Call array.
+    /// @dev Useful to skip an ABI decode-encode step when transmitting callback data.
+    /// @param data An abi-encoded Call[]
+    function multicallHub(bytes calldata data) internal {
+        (bool success, bytes memory returnData) = HUB.call(bytes.concat(IHub.multicallFromBundler.selector, data));
+        if (!success) {
+            BundlerLib.lowLevelRevert(returnData);
+        }
+    }
 }

--- a/src/Hub.sol
+++ b/src/Hub.sol
@@ -71,7 +71,7 @@ contract Hub is IHub {
     /* INTERNAL */
 
     /// @notice Executes a series of calls to bundlers.
-    function _multicall(Call[] memory calls) internal {
+    function _multicall(Call[] calldata calls) internal {
         for (uint256 i; i < calls.length; ++i) {
             address previousBundler = currentBundler();
             address bundler = calls[i].to;

--- a/src/MorphoBundler.sol
+++ b/src/MorphoBundler.sol
@@ -261,6 +261,6 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     function _callback(bytes calldata data) internal {
         require(msg.sender == address(MORPHO), ErrorsLib.UnauthorizedSender(msg.sender));
 
-        IHub(HUB).multicallFromBundler(abi.decode(data, (Call[])));
+        multicallHub(data);
     }
 }


### PR DESCRIPTION
Replaces #23.

Skips an ABI decode-encode step when calling back the hub, and keep `_multicall` argument in calldata.

* It saves 13.8k gas (0.18%) in `testMigrateBorrowerDaiToSDaiWithPermit2` (AaveV2 migration test)
* It saves 8.6k gas (0.18%) in a `testFullCollateralSwap` (paraswap test in #3).

I picked both examples because they put a lot of data in the callback bundle.