### PR TITLE
Ci/avoid file busy

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -89,6 +89,9 @@ jobs:
 
       - uses: ./.github/actions/install-cache
 
+      - name: Forge build
+        run: yarn build
+
       - name: Run fork tests on chain ${{ matrix.chain }} in ${{ matrix.type }} mode
         run: yarn test:fork --chain ${{ matrix.chain }}
         env:


### PR DESCRIPTION
Seeing a lot of `text file busy` errors in CI, following mattsse's advice [here](https://github.com/foundry-rs/foundry/issues/4736) I'm trying a build step before `forge test`.