### PR TITLE
test: simplify bound pk

### DIFF
--- a/test/MorphoModuleLocalTest.sol
+++ b/test/MorphoModuleLocalTest.sol
@@ -50,7 +50,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testSetAuthorizationWithSig(uint256 privateKey, uint32 deadline) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         deadline = uint32(bound(deadline, block.timestamp + 1, type(uint32).max));
 
         bundle.push(_morphoSetAuthorizationWithSig(privateKey, true, 0, false));
@@ -63,7 +64,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testSetAuthorizationWithSigRevert(uint256 privateKey, uint32 deadline) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         deadline = uint32(bound(deadline, block.timestamp + 1, type(uint32).max));
 
         bundle.push(_morphoSetAuthorizationWithSig(privateKey, true, 0, false));
@@ -224,7 +226,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testWithdraw(uint256 privateKey, uint256 amount, uint256 withdrawnShares) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         approveERC20ToMorphoAndModule(user);
 
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
@@ -279,7 +282,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testSupplyCollateralBorrow(uint256 privateKey, uint256 amount) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         approveERC20ToMorphoAndModule(user);
 
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
@@ -304,7 +308,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testSupplyCollateralBorrowViaCallback(uint256 privateKey, uint256 amount) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         approveERC20ToMorphoAndModule(user);
 
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
@@ -353,7 +358,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testRepayWithdrawCollateral(uint256 privateKey, uint256 amount) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         approveERC20ToMorphoAndModule(user);
 
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
@@ -382,7 +388,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testRepayMaxAndWithdrawCollateral(uint256 privateKey, uint256 amount) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         approveERC20ToMorphoAndModule(user);
 
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
@@ -411,7 +418,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testRepayWithdrawCollateralViaCallback(uint256 privateKey, uint256 amount) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         approveERC20ToMorphoAndModule(user);
 
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
@@ -453,7 +461,8 @@ contract MorphoModuleLocalTest is MetaMorphoLocalTest {
 
     function testBundleTransactions(uint256 privateKey, uint256 size, uint256 seedAction, uint256 seedAmount) public {
         address user;
-        (privateKey, user) = _boundPrivateKey(privateKey);
+        privateKey = _boundPrivateKey(privateKey);
+        user = vm.addr(privateKey);
         approveERC20ToMorphoAndModule(user);
 
         bundle.push(_morphoSetAuthorizationWithSig(privateKey, true, 0, false));

--- a/test/fork/ModuleForkTest.sol
+++ b/test/fork/ModuleForkTest.sol
@@ -15,7 +15,8 @@ contract EthereumModuleForkTest is ForkTest {
     using SafeTransferLib for ERC20;
 
     function testSupplyWithPermit2(uint256 seed, uint256 amount, address onBehalf, uint256 deadline) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         vm.assume(onBehalf != address(0));
         vm.assume(onBehalf != address(morpho));

--- a/test/fork/Permit2ModuleForkTest.sol
+++ b/test/fork/Permit2ModuleForkTest.sol
@@ -14,7 +14,8 @@ contract Permit2ModuleForkTest is ForkTest {
     address internal DAI = getAddress("DAI");
 
     function testApprove2(uint256 seed, uint256 amount) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
 
         MarketParams memory marketParams = _randomMarketParams(seed);
@@ -40,7 +41,8 @@ contract Permit2ModuleForkTest is ForkTest {
     }
 
     function testApprove2Batch(uint256 amount0, uint256 amount1) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         amount0 = bound(amount0, MIN_AMOUNT, MAX_AMOUNT);
         amount1 = bound(amount1, MIN_AMOUNT, MAX_AMOUNT);
 
@@ -100,7 +102,8 @@ contract Permit2ModuleForkTest is ForkTest {
     }
 
     function testApprove2InvalidNonce(uint256 seed, uint256 amount) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
 
         MarketParams memory marketParams = _randomMarketParams(seed);
@@ -114,7 +117,8 @@ contract Permit2ModuleForkTest is ForkTest {
     }
 
     function testApprove2BatchInvalidNonce(uint256 amount0, uint256 amount1) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         amount0 = bound(amount0, MIN_AMOUNT, MAX_AMOUNT);
         amount1 = bound(amount1, MIN_AMOUNT, MAX_AMOUNT);
 

--- a/test/fork/PermitModuleForkTest.sol
+++ b/test/fork/PermitModuleForkTest.sol
@@ -29,7 +29,8 @@ contract PermitModuleForkTest is ForkTest {
     }
 
     function testPermitDai(address spender, uint256 expiry) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         vm.assume(spender != address(0));
         expiry = bound(expiry, block.timestamp, type(uint48).max);
@@ -49,7 +50,8 @@ contract PermitModuleForkTest is ForkTest {
     }
 
     function testPermitDaiRevert(address spender, uint256 expiry) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         vm.assume(spender != address(0));
         expiry = bound(expiry, block.timestamp, type(uint48).max);
 
@@ -87,7 +89,8 @@ contract PermitModuleForkTest is ForkTest {
     }
 
     function testPermit(uint256 amount, address spender, uint256 deadline) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         vm.assume(spender != address(0));
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
         deadline = bound(deadline, block.timestamp, type(uint48).max);
@@ -110,7 +113,8 @@ contract PermitModuleForkTest is ForkTest {
     }
 
     function testPermitRevert(uint256 amount, address spender, uint256 deadline) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         vm.assume(spender != address(0));
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
         deadline = bound(deadline, block.timestamp, type(uint48).max);
@@ -124,7 +128,8 @@ contract PermitModuleForkTest is ForkTest {
     }
 
     function testTransferFrom(uint256 amount, uint256 deadline) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
         deadline = bound(deadline, block.timestamp, type(uint48).max);
 

--- a/test/fork/StEthModuleForkTest.sol
+++ b/test/fork/StEthModuleForkTest.sol
@@ -76,7 +76,8 @@ contract EthereumStEthModuleForkTest is ForkTest {
     }
 
     function testWrapStEth(uint256 amount) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
 
         deal(ST_ETH, user, amount);
@@ -113,7 +114,8 @@ contract EthereumStEthModuleForkTest is ForkTest {
     }
 
     function testUnwrapWstEth(uint256 amount) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
 
         bundle.push(_approve2(privateKey, WST_ETH, amount, 0, false));

--- a/test/fork/migration/AaveV2MigrationModuleForkTest.sol
+++ b/test/fork/migration/AaveV2MigrationModuleForkTest.sol
@@ -63,7 +63,8 @@ contract AaveV2MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateBorrowerWithPermit2() public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 
@@ -99,7 +100,8 @@ contract AaveV2MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateBorrowerDaiToSDaiWithPermit2() public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _initMarket(S_DAI, WETH);
         _provideLiquidity(borrowed);
@@ -139,7 +141,8 @@ contract AaveV2MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateStEthPositionWithPermit2() public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _initMarket(WST_ETH, marketParams.loanToken);
         _provideLiquidity(borrowed);
@@ -184,7 +187,8 @@ contract AaveV2MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierWithPermit2(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 1);
@@ -212,7 +216,8 @@ contract AaveV2MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierToVaultWithPermit2(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 1);

--- a/test/fork/migration/AaveV3MigrationModuleForkTest.sol
+++ b/test/fork/migration/AaveV3MigrationModuleForkTest.sol
@@ -69,7 +69,8 @@ contract AaveV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateBorrowerWithATokenPermit() public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 
@@ -102,7 +103,8 @@ contract AaveV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateBorrowerWithPermit2() public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 
@@ -138,7 +140,8 @@ contract AaveV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateUSDTPositionWithPermit2() public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         uint256 amountUsdt = collateralSupplied / 1e10;
 
@@ -178,7 +181,8 @@ contract AaveV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierWithATokenPermit(uint256 supplied) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 1);
@@ -203,7 +207,8 @@ contract AaveV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierWithPermit2(uint256 supplied) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 1);
@@ -231,7 +236,8 @@ contract AaveV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierToVaultWithATokenPermit(uint256 supplied) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 1);
@@ -256,7 +262,8 @@ contract AaveV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierToVaultWithPermit2(uint256 supplied) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 1);

--- a/test/fork/migration/AaveV3OptimizerMigrationModuleForkTest.sol
+++ b/test/fork/migration/AaveV3OptimizerMigrationModuleForkTest.sol
@@ -57,7 +57,8 @@ contract AaveV3OptimizerMigrationModuleForkTest is MigrationForkTest {
     }
 
     function testAaveV3OtimizerAuthorizationWithSigRevert(address owner) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         vm.assume(owner != user);
 
@@ -84,7 +85,8 @@ contract AaveV3OptimizerMigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateBorrowerWithOptimizerPermit() public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 
@@ -118,7 +120,8 @@ contract AaveV3OptimizerMigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateUSDTBorrowerWithOptimizerPermit() public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         vm.startPrank(getAddress("MORPHO_SAFE_OWNER"));
         IMorphoSettersPartial(AAVE_V3_OPTIMIZER).setIsSupplyCollateralPaused(USDT, false);
         IMorphoSettersPartial(AAVE_V3_OPTIMIZER).setAssetIsCollateral(USDT, true);
@@ -157,7 +160,8 @@ contract AaveV3OptimizerMigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierWithOptimizerPermit(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 2);
@@ -179,7 +183,8 @@ contract AaveV3OptimizerMigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierToVaultWithOptimizerPermit(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied + 2);

--- a/test/fork/migration/CompoundV2ERC20MigrationModuleForkTest.sol
+++ b/test/fork/migration/CompoundV2ERC20MigrationModuleForkTest.sol
@@ -61,7 +61,8 @@ contract CompoundV2ERC20MigrationModuleForkTest is MigrationForkTest {
     function testMigrateBorrowerWithPermit2() public onlyEthereum {
         uint256 collateral = 10 ether;
         uint256 borrowed = 1e6;
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 
@@ -97,7 +98,8 @@ contract CompoundV2ERC20MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierWithPermit2(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied);
@@ -125,7 +127,8 @@ contract CompoundV2ERC20MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierToVaultWithPermit2(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 100, 100 ether);
 
         deal(marketParams.loanToken, user, supplied);

--- a/test/fork/migration/CompoundV2EthBorrowableMigrationModuleForkTest.sol
+++ b/test/fork/migration/CompoundV2EthBorrowableMigrationModuleForkTest.sol
@@ -75,7 +75,8 @@ contract CompoundV2EthLoanMigrationModuleForkTest is MigrationForkTest {
         uint256 collateral = 10_000 ether;
         uint256 borrowed = 1 ether;
 
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 
@@ -113,7 +114,8 @@ contract CompoundV2EthLoanMigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierWithPermit2(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 0.1 ether, 100 ether);
 
         deal(user, supplied);
@@ -140,7 +142,8 @@ contract CompoundV2EthLoanMigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierToVaultWithPermit2(uint256 supplied) public onlyEthereum {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 0.1 ether, 100 ether);
 
         deal(user, supplied);

--- a/test/fork/migration/CompoundV2EthCollateralMigrationModuleForkTest.sol
+++ b/test/fork/migration/CompoundV2EthCollateralMigrationModuleForkTest.sol
@@ -54,7 +54,8 @@ contract CompoundV2EthCollateralMigrationModuleForkTest is MigrationForkTest {
         uint256 collateral = 10 ether;
         uint256 borrowed = 1 ether;
 
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 

--- a/test/fork/migration/CompoundV3MigrationModuleForkTest.sol
+++ b/test/fork/migration/CompoundV3MigrationModuleForkTest.sol
@@ -45,14 +45,15 @@ contract CompoundV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testCompoundV3AllowBySigUnauthorized() public {
-        (uint256 privateKey,) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
 
         vm.expectPartialRevert(ErrorsLib.UnauthorizedSender.selector);
         migrationModule.compoundV3AllowBySig(C_WETH_V3, true, 0, SIGNATURE_DEADLINE, 0, 0, 0, false);
     }
 
     function testCompoundVAuthorizationWithSigRevert(address owner) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         vm.assume(owner != user);
 
@@ -77,7 +78,8 @@ contract CompoundV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateBorrowerWithCompoundAllowance() public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         _provideLiquidity(borrowed);
 
@@ -111,7 +113,8 @@ contract CompoundV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierWithCompoundAllowance(uint256 supplied) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 101, 100 ether);
 
         deal(marketParams.loanToken, user, supplied);
@@ -136,7 +139,8 @@ contract CompoundV3MigrationModuleForkTest is MigrationForkTest {
     }
 
     function testMigrateSupplierToVaultWithCompoundAllowance(uint256 supplied) public {
-        (uint256 privateKey, address user) = _boundPrivateKey(pickUint());
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
         supplied = bound(supplied, 101, 100 ether);
 
         deal(marketParams.loanToken, user, supplied);

--- a/test/helpers/CommonTest.sol
+++ b/test/helpers/CommonTest.sol
@@ -91,13 +91,13 @@ abstract contract CommonTest is Test {
         morpho.setAuthorization(address(this), true);
     }
 
-    function _boundPrivateKey(uint256 privateKey) internal returns (uint256, address) {
+    function _boundPrivateKey(uint256 privateKey) internal returns (uint256) {
         privateKey = bound(privateKey, 1, type(uint160).max);
 
         address user = vm.addr(privateKey);
-        vm.label(user, "User");
+        vm.label(user, "address of generated private key");
 
-        return (privateKey, user);
+        return privateKey;
     }
 
     function _delegatePrank(address target, bytes memory callData) internal {


### PR DESCRIPTION
on top of #56 

not mandatory

I found it weird to have "boundPrivateKey" return an address