### PR TITLE
refactor: remove callback from the base module

### DIFF
--- a/src/BaseModule.sol
+++ b/src/BaseModule.sol
@@ -72,13 +72,4 @@ abstract contract BaseModule {
     function _initiator() internal view returns (address) {
         return IBundler(BUNDLER).initiator();
     }
-
-    /// @notice Calls bundler.multicallFromModule with an already encoded Call array.
-    /// @dev Useful to skip an ABI decode-encode step when transmitting callback data.
-    /// @param data An abi-encoded Call[].
-    function _multicallBundler(bytes calldata data) internal {
-        (bool success, bytes memory returnData) =
-            BUNDLER.call(bytes.concat(IBundler.multicallFromModule.selector, data));
-        if (!success) ModuleLib.lowLevelRevert(returnData);
-    }
 }

--- a/src/GenericModule1.sol
+++ b/src/GenericModule1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {BaseModule} from "./BaseModule.sol";
+import {BaseModule, IBundler} from "./BaseModule.sol";
 
 import {MarketParams, Signature, Authorization, IMorpho} from "../lib/morpho-blue/src/interfaces/IMorpho.sol";
 
@@ -436,6 +436,9 @@ contract GenericModule1 is BaseModule {
         require(msg.sender == address(MORPHO), ErrorsLib.UnauthorizedSender());
         // No need to approve Morpho to pull tokens because it should already be approved max.
 
-        _multicallBundler(data);
+        // Low-level call to skip ABI decode-encode.
+        (bool success, bytes memory returnData) =
+            BUNDLER.call(bytes.concat(IBundler.multicallFromModule.selector, data));
+        if (!success) ModuleLib.lowLevelRevert(returnData);
     }
 }


### PR DESCRIPTION
the rationale is that doing a callback shouldn't be common, and it's dangerous for the user. I'm not 100% convinced though because it makes the interaction with the Bundler non canonic.