### PR TITLE
refactor: eth transfer from

### DIFF
--- a/src/BaseModule.sol
+++ b/src/BaseModule.sol
@@ -65,6 +65,16 @@ abstract contract BaseModule {
         SafeTransferLib.safeTransfer(ERC20(token), receiver, amount);
     }
 
+    function transferFromNative(address receiver, uint256 amount) external onlyBundler {
+        require(receiver != address(0), ErrorsLib.ZeroAddress());
+
+        if (amount == type(uint256).max) amount = address(this).balance;
+
+        require(amount != 0, ErrorsLib.ZeroAmount());
+
+        IBundler(BUNDLER).transferFromNative(receiver, amount);
+    }
+
     /* INTERNAL */
 
     /// @notice Returns the current initiator stored in the module.

--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -44,6 +44,13 @@ contract Bundler is IBundler {
         _multicall(bundle);
     }
 
+    /// @notice Transfers Ether to an address.
+    /// @dev Can only be called by the current module.
+    function transferFromNative(address to, uint256 value) external {
+        require(msg.sender == currentModule, ErrorsLib.UnauthorizedSender());
+        payable(to).transfer(value);
+    }
+
     /* INTERNAL */
 
     /// @notice Executes a series of calls to modules.

--- a/src/interfaces/IBundler.sol
+++ b/src/interfaces/IBundler.sol
@@ -14,6 +14,7 @@ struct Call {
 interface IBundler {
     function multicall(Call[] calldata bundle) external payable;
     function multicallFromModule(Call[] calldata bundle) external;
+    function transferFromNative(address to, uint256 value) external;
     function currentModule() external view returns (address module);
     function initiator() external view returns (address);
 }


### PR DESCRIPTION
idea to make ETH management look more like erc20 management (but it's not perfect because you need to send to the bundler anyway..)

note that it would be possible to abstract it in the transferFrom action with a special token address, but not convinced