### PR TITLE
experimental: AA-compatible modules

### DIFF
--- a/src/modules/EthereumGeneralModule1.sol
+++ b/src/modules/EthereumGeneralModule1.sol
@@ -71,7 +71,7 @@ contract EthereumGeneralModule1 is GeneralModule1 {
     /// withdrawTo.
     /// @param receiver The address to send the tokens to.
     /// @param amount The amount of tokens to unwrap.
-    function morphoWrapperWithdrawTo(address receiver, uint256 amount) external onlyBundler {
+    function morphoWrapperWithdrawTo(address receiver, uint256 amount) external onlyBundlerOrDelegatecall {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         if (amount == type(uint256).max) amount = ERC20(MORPHO_TOKEN).balanceOf(address(this));
@@ -92,7 +92,7 @@ contract EthereumGeneralModule1 is GeneralModule1 {
     function stakeEth(uint256 amount, uint256 maxSharePriceE27, address referral, address receiver)
         external
         payable
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         if (amount == type(uint256).max) amount = address(this).balance;
 
@@ -108,7 +108,7 @@ contract EthereumGeneralModule1 is GeneralModule1 {
     /// @dev stETH must have been previously sent to the module.
     /// @param amount The amount of stEth to wrap. Pass `type(uint).max` to wrap the module's balance.
     /// @param receiver The account receiving the wStETH tokens.
-    function wrapStEth(uint256 amount, address receiver) external onlyBundler {
+    function wrapStEth(uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         if (amount == type(uint256).max) amount = ERC20(ST_ETH).balanceOf(address(this));
 
         require(amount != 0, ErrorsLib.ZeroAmount());
@@ -121,7 +121,7 @@ contract EthereumGeneralModule1 is GeneralModule1 {
     /// @dev wStETH must have been previously sent to the module.
     /// @param amount The amount of wStEth to unwrap. Pass `type(uint).max` to unwrap the module's balance.
     /// @param receiver The account receiving the stETH tokens.
-    function unwrapStEth(uint256 amount, address receiver) external onlyBundler {
+    function unwrapStEth(uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         if (amount == type(uint256).max) amount = ERC20(WST_ETH).balanceOf(address(this));
 
         require(amount != 0, ErrorsLib.ZeroAmount());

--- a/src/modules/GeneralModule1.sol
+++ b/src/modules/GeneralModule1.sol
@@ -61,7 +61,7 @@ contract GeneralModule1 is CoreModule {
     /// @param receiver The account receiving the wrapped tokens.
     /// @param amount The amount of underlying tokens to deposit. Pass `type(uint).max` to deposit the module's
     /// underlying balance.
-    function erc20WrapperDepositFor(address wrapper, address receiver, uint256 amount) external onlyBundler {
+    function erc20WrapperDepositFor(address wrapper, address receiver, uint256 amount) external onlyBundlerOrDelegatecall {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         address underlying = address(ERC20Wrapper(wrapper).underlying());
@@ -81,7 +81,7 @@ contract GeneralModule1 is CoreModule {
     /// @param receiver The address receiving the underlying tokens.
     /// @param amount The amount of wrapped tokens to burn. Pass `type(uint).max` to burn the module's wrapped token
     /// balance.
-    function erc20WrapperWithdrawTo(address wrapper, address receiver, uint256 amount) external onlyBundler {
+    function erc20WrapperWithdrawTo(address wrapper, address receiver, uint256 amount) external onlyBundlerOrDelegatecall {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         if (amount == type(uint256).max) amount = ERC20(wrapper).balanceOf(address(this));
@@ -102,7 +102,7 @@ contract GeneralModule1 is CoreModule {
     /// @param receiver The address to which shares will be minted.
     function erc4626Mint(address vault, uint256 shares, uint256 maxSharePriceE27, address receiver)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
         require(shares != 0, ErrorsLib.ZeroShares());
@@ -122,7 +122,7 @@ contract GeneralModule1 is CoreModule {
     /// @param receiver The address to which shares will be minted.
     function erc4626Deposit(address vault, uint256 assets, uint256 maxSharePriceE27, address receiver)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
@@ -148,7 +148,7 @@ contract GeneralModule1 is CoreModule {
     /// @param owner The address on behalf of which the assets are withdrawn. Can only be the module or the initiator.
     function erc4626Withdraw(address vault, uint256 assets, uint256 minSharePriceE27, address receiver, address owner)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
         require(owner == address(this) || owner == _initiator(), ErrorsLib.UnexpectedOwner());
@@ -169,7 +169,7 @@ contract GeneralModule1 is CoreModule {
     /// @param owner The address on behalf of which the shares are redeemed. Can only be the module or the initiator.
     function erc4626Redeem(address vault, uint256 shares, uint256 minSharePriceE27, address receiver, address owner)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
         require(owner == address(this) || owner == _initiator(), ErrorsLib.UnexpectedOwner());
@@ -220,7 +220,7 @@ contract GeneralModule1 is CoreModule {
         uint256 maxSharePriceE27,
         address onBehalf,
         bytes calldata data
-    ) external onlyBundler {
+    ) external onlyBundlerOrDelegatecall {
         // Do not check `onBehalf` against the zero address as it's done in Morpho.
         require(onBehalf != address(this), ErrorsLib.ModuleAddress());
 
@@ -248,7 +248,7 @@ contract GeneralModule1 is CoreModule {
         uint256 assets,
         address onBehalf,
         bytes calldata data
-    ) external onlyBundler {
+    ) external onlyBundlerOrDelegatecall {
         // Do not check `onBehalf` against the zero address as it's done at Morpho's level.
         require(onBehalf != address(this), ErrorsLib.ModuleAddress());
 
@@ -277,7 +277,7 @@ contract GeneralModule1 is CoreModule {
         uint256 shares,
         uint256 minSharePriceE27,
         address receiver
-    ) external onlyBundler {
+    ) external onlyBundlerOrDelegatecall {
         (uint256 borrowedAssets, uint256 borrowedShares) =
             MORPHO.borrow(marketParams, assets, shares, _initiator(), receiver);
 
@@ -302,7 +302,7 @@ contract GeneralModule1 is CoreModule {
         uint256 maxSharePriceE27,
         address onBehalf,
         bytes calldata data
-    ) external onlyBundler {
+    ) external onlyBundlerOrDelegatecall {
         // Do not check `onBehalf` against the zero address as it's done at Morpho's level.
         require(onBehalf != address(this), ErrorsLib.ModuleAddress());
 
@@ -339,7 +339,7 @@ contract GeneralModule1 is CoreModule {
         uint256 shares,
         uint256 minSharePriceE27,
         address receiver
-    ) external onlyBundler {
+    ) external onlyBundlerOrDelegatecall {
         if (shares == type(uint256).max) {
             shares = MorphoLib.supplyShares(MORPHO, marketParams.id(), _initiator());
             require(shares != 0, ErrorsLib.ZeroAmount());
@@ -359,7 +359,7 @@ contract GeneralModule1 is CoreModule {
     /// @param receiver The address that will receive the collateral assets.
     function morphoWithdrawCollateral(MarketParams calldata marketParams, uint256 assets, address receiver)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         if (assets == type(uint256).max) assets = MorphoLib.collateral(MORPHO, marketParams.id(), _initiator());
         require(assets != 0, ErrorsLib.ZeroAmount());
@@ -370,7 +370,7 @@ contract GeneralModule1 is CoreModule {
     /// @param token The address of the token to flash loan.
     /// @param assets The amount of assets to flash loan.
     /// @param data Arbitrary data to pass to the `onMorphoFlashLoan` callback.
-    function morphoFlashLoan(address token, uint256 assets, bytes calldata data) external onlyBundler {
+    function morphoFlashLoan(address token, uint256 assets, bytes calldata data) external onlyBundlerOrDelegatecall {
         require(assets != 0, ErrorsLib.ZeroAmount());
         ModuleLib.approveMaxToIfAllowanceZero(token, address(MORPHO));
 
@@ -383,7 +383,7 @@ contract GeneralModule1 is CoreModule {
     /// @param token The address of the ERC20 token to transfer.
     /// @param receiver The address that will receive the tokens.
     /// @param amount The amount of token to transfer. Pass `type(uint).max` to transfer the initiator's balance.
-    function transferFrom2(address token, address receiver, uint256 amount) external onlyBundler {
+    function transferFrom2(address token, address receiver, uint256 amount) external onlyBundlerOrDelegatecall {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         address _initiator = _initiator();
@@ -402,7 +402,7 @@ contract GeneralModule1 is CoreModule {
     /// @param token The address of the ERC20 token to transfer.
     /// @param receiver The address that will receive the tokens.
     /// @param amount The amount of token to transfer. Pass `type(uint).max` to transfer the initiator's balance.
-    function erc20TransferFrom(address token, address receiver, uint256 amount) external onlyBundler {
+    function erc20TransferFrom(address token, address receiver, uint256 amount) external onlyBundlerOrDelegatecall {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         address _initiator = _initiator();
@@ -419,7 +419,7 @@ contract GeneralModule1 is CoreModule {
     /// @dev Native tokens must have been previously sent to the module.
     /// @param amount The amount of native token to wrap. Pass `type(uint).max` to wrap the module's balance.
     /// @param receiver The account receiving the wrapped native tokens.
-    function wrapNative(uint256 amount, address receiver) external onlyBundler {
+    function wrapNative(uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         if (amount == type(uint256).max) amount = address(this).balance;
 
         require(amount != 0, ErrorsLib.ZeroAmount());
@@ -433,7 +433,7 @@ contract GeneralModule1 is CoreModule {
     /// @param amount The amount of wrapped native token to unwrap. Pass `type(uint).max` to unwrap the module's
     /// balance.
     /// @param receiver The account receiving the native tokens.
-    function unwrapNative(uint256 amount, address receiver) external onlyBundler {
+    function unwrapNative(uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         if (amount == type(uint256).max) amount = WRAPPED_NATIVE.balanceOf(address(this));
 
         require(amount != 0, ErrorsLib.ZeroAmount());

--- a/src/modules/migration/AaveV2MigrationModule.sol
+++ b/src/modules/migration/AaveV2MigrationModule.sol
@@ -39,7 +39,7 @@ contract AaveV2MigrationModule is CoreModule {
     /// @param onBehalf The account on behalf of which the debt is repaid.
     function aaveV2Repay(address token, uint256 amount, uint256 interestRateMode, address onBehalf)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         // Amount will be capped at `onBehalf`'s debt by Aave.
         if (amount == type(uint256).max) amount = ERC20(token).balanceOf(address(this));
@@ -58,7 +58,7 @@ contract AaveV2MigrationModule is CoreModule {
     /// initiator's max withdrawable amount. Pass
     /// `type(uint).max` to always withdraw all.
     /// @param receiver The account receiving the withdrawn tokens.
-    function aaveV2Withdraw(address token, uint256 amount, address receiver) external onlyBundler {
+    function aaveV2Withdraw(address token, uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         require(amount != 0, ErrorsLib.ZeroAmount());
         AAVE_V2_POOL.withdraw(token, amount, receiver);
     }

--- a/src/modules/migration/AaveV3MigrationModule.sol
+++ b/src/modules/migration/AaveV3MigrationModule.sol
@@ -40,7 +40,7 @@ contract AaveV3MigrationModule is CoreModule {
     /// @param onBehalf The account on behalf of which the debt is repaid.
     function aaveV3Repay(address token, uint256 amount, uint256 interestRateMode, address onBehalf)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         // Amount will be capped at `onBehalf`'s debt by Aave.
         if (amount == type(uint256).max) amount = ERC20(token).balanceOf(address(this));
@@ -59,7 +59,7 @@ contract AaveV3MigrationModule is CoreModule {
     /// initiator's max withdrawable amount. Pass
     /// `type(uint).max` to always withdraw all.
     /// @param receiver The account receiving the withdrawn tokens.
-    function aaveV3Withdraw(address token, uint256 amount, address receiver) external onlyBundler {
+    function aaveV3Withdraw(address token, uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         require(amount != 0, ErrorsLib.ZeroAmount());
         AAVE_V3_POOL.withdraw(token, amount, receiver);
     }

--- a/src/modules/migration/AaveV3OptimizerMigrationModule.sol
+++ b/src/modules/migration/AaveV3OptimizerMigrationModule.sol
@@ -36,7 +36,7 @@ contract AaveV3OptimizerMigrationModule is CoreModule {
     /// `onBehalf`s debt. Pass `type(uint).max` to repay the repay the maximum repayable debt (minimum of the module's
     /// balance and `onBehalf`'s debt).
     /// @param onBehalf The account on behalf of which the debt is repaid.
-    function aaveV3OptimizerRepay(address underlying, uint256 amount, address onBehalf) external onlyBundler {
+    function aaveV3OptimizerRepay(address underlying, uint256 amount, address onBehalf) external onlyBundlerOrDelegatecall {
         // Amount will be capped at `onBehalf`'s debt by the optimizer.
         if (amount == type(uint256).max) amount = ERC20(underlying).balanceOf(address(this));
 
@@ -57,7 +57,7 @@ contract AaveV3OptimizerMigrationModule is CoreModule {
     /// @param receiver The account that will receive the withdrawn assets.
     function aaveV3OptimizerWithdraw(address underlying, uint256 amount, uint256 maxIterations, address receiver)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         require(amount != 0, ErrorsLib.ZeroAmount());
         AAVE_V3_OPTIMIZER.withdraw(underlying, amount, _initiator(), receiver, maxIterations);
@@ -72,7 +72,7 @@ contract AaveV3OptimizerMigrationModule is CoreModule {
     /// @param receiver The account that will receive the withdrawn assets.
     function aaveV3OptimizerWithdrawCollateral(address underlying, uint256 amount, address receiver)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         require(amount != 0, ErrorsLib.ZeroAmount());
         AAVE_V3_OPTIMIZER.withdrawCollateral(underlying, amount, _initiator(), receiver);

--- a/src/modules/migration/CompoundV2MigrationModule.sol
+++ b/src/modules/migration/CompoundV2MigrationModule.sol
@@ -37,7 +37,7 @@ contract CompoundV2MigrationModule is CoreModule {
     /// debt. Pass `type(uint).max` to repay the maximum repayable debt (minimum of the module's balance and
     /// `onBehalf`'s debt).
     /// @param onBehalf The account on behalf of which the debt is repaid.
-    function compoundV2RepayErc20(address cToken, uint256 amount, address onBehalf) external onlyBundler {
+    function compoundV2RepayErc20(address cToken, uint256 amount, address onBehalf) external onlyBundlerOrDelegatecall {
         require(cToken != C_ETH, ErrorsLib.CTokenIsCETH());
 
         address underlying = ICToken(cToken).underlying();
@@ -59,7 +59,7 @@ contract CompoundV2MigrationModule is CoreModule {
     /// Pass `type(uint).max` to repay the maximum repayable debt (minimum of the module's balance and `onBehalf`'s
     /// debt).
     /// @param onBehalf The account on behalf of which the debt is repaid.
-    function compoundV2RepayEth(uint256 amount, address onBehalf) external onlyBundler {
+    function compoundV2RepayEth(uint256 amount, address onBehalf) external onlyBundlerOrDelegatecall {
         if (amount == type(uint256).max) amount = address(this).balance;
         amount = Math.min(amount, ICEth(C_ETH).borrowBalanceCurrent(onBehalf));
 
@@ -75,7 +75,7 @@ contract CompoundV2MigrationModule is CoreModule {
     /// is capped at the module's max redeemable amount. Pass `type(uint).max` to always
     /// redeem the module's balance.
     /// @param receiver The account receiving the redeemed assets.
-    function compoundV2RedeemErc20(address cToken, uint256 amount, address receiver) external onlyBundler {
+    function compoundV2RedeemErc20(address cToken, uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         require(cToken != C_ETH, ErrorsLib.CTokenIsCETH());
 
         amount = Math.min(amount, ICToken(cToken).balanceOf(address(this)));
@@ -95,7 +95,7 @@ contract CompoundV2MigrationModule is CoreModule {
     /// @param amount The amount of cEth to redeem. Unlike with `morphoWithdraw` using a shares argument, the amount is
     /// capped at the module's max redeemable amount. Pass `type(uint).max` to redeem the module's balance.
     /// @param receiver The account receiving the redeemed ETH.
-    function compoundV2RedeemEth(uint256 amount, address receiver) external onlyBundler {
+    function compoundV2RedeemEth(uint256 amount, address receiver) external onlyBundlerOrDelegatecall {
         amount = Math.min(amount, ICEth(C_ETH).balanceOf(address(this)));
 
         require(amount != 0, ErrorsLib.ZeroAmount());

--- a/src/modules/migration/CompoundV3MigrationModule.sol
+++ b/src/modules/migration/CompoundV3MigrationModule.sol
@@ -28,7 +28,7 @@ contract CompoundV3MigrationModule is CoreModule {
     /// debt. Pass `type(uint).max` to repay the maximum repayable debt (minimum of the module's balance and
     /// `onBehalf`'s debt).
     /// @param onBehalf The account on behalf of which the debt is repaid.
-    function compoundV3Repay(address instance, uint256 amount, address onBehalf) external onlyBundler {
+    function compoundV3Repay(address instance, uint256 amount, address onBehalf) external onlyBundlerOrDelegatecall {
         address asset = ICompoundV3(instance).baseToken();
 
         if (amount == type(uint256).max) amount = ERC20(asset).balanceOf(address(this));
@@ -53,7 +53,7 @@ contract CompoundV3MigrationModule is CoreModule {
     /// @param receiver The account receiving the withdrawn assets.
     function compoundV3WithdrawFrom(address instance, address asset, uint256 amount, address receiver)
         external
-        onlyBundler
+        onlyBundlerOrDelegatecall
     {
         address _initiator = _initiator();
         uint256 balance = asset == ICompoundV3(instance).baseToken()

--- a/test/helpers/mocks/ModuleMock.sol
+++ b/test/helpers/mocks/ModuleMock.sol
@@ -11,7 +11,7 @@ event CurrentModule(address);
 contract ModuleMock is CoreModule {
     constructor(address bundler) CoreModule(bundler) {}
 
-    function isProtected() external payable onlyBundler {
+    function isProtected() external payable onlyBundlerOrDelegatecall {
         emit CurrentModule(IBundler(BUNDLER).currentModule());
     }
 
@@ -23,13 +23,13 @@ contract ModuleMock is CoreModule {
         emit Initiator(_initiator());
     }
 
-    function callbackBundler(Call[] calldata calls) external onlyBundler {
+    function callbackBundler(Call[] calldata calls) external onlyBundlerOrDelegatecall {
         emit CurrentModule(IBundler(BUNDLER).currentModule());
         IBundler(BUNDLER).multicallFromModule(calls);
         emit CurrentModule(IBundler(BUNDLER).currentModule());
     }
 
-    function callbackBundlerWithMulticall() external onlyBundler {
+    function callbackBundlerWithMulticall() external onlyBundlerOrDelegatecall {
         IBundler(BUNDLER).multicall(new Call[](0));
     }
 


### PR DESCRIPTION
Idea to make modules compatible with AA.

* Without AA, modules are third-parties approved by the EOA.
* With AA, modules act as the EOA.

In this PR `onlyBundler` is replaced by `onlyBundlerOrDelegatecall`. It makes modules compatible with this setup:
1. The EOA replaces his contract code by a 7702 contract with multicall-like abilities.
2. This contract is called with a bundle that delegatecalls modules.
3. Each module acts as the EOA, since it was delegatecalled by a contract at the EOA's address.

Here handling callbacks is the responsbility of the 7702 contract that lives at the EOA's address: even during a delegatecall to a module, calls to the EOA address will execute the 7702 contract's code. So it needs a proper fallback function in place that can respond to `onMorphoSupply`, etc. and delegatecall more modules to continue the bundle execution.

Limitations:
* When a module executes under an EOA's address, it is no longer unsafe to do things such as borrow on behalf of another account. But modules are constrained to borrow on behalf of `initiator`. So these modules are too constrained relative to what they could be if they were written with only AA in mind. On the flipside, it means we have feature parity for all morpho users so it's simpler to manage.

Alternatives:
* Keep the normal "modules are third-parties approved by EOA" approach even when the EOA has used EIP-7702.
* Do not modify the current modules, deploy a copy of all modules specialized to work with AA-enabled EOAs.