### PR TITLE
chore: ignore test contract size warning

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ fs_permissions = [
 libs = ["lib"]
 via-ir = true
 optimizer_runs = 999999
+ignored_error_codes = ["transient-storage"]
 ignored_warnings_from = ["test"]
 
 [profile.default.fuzz]


### PR DESCRIPTION
we get back the transient storage warning, but at least we don't have dozens of warning about test files being too big (which could hide actually useful warnings)