### PR TITLE
test: missed reenter

### DIFF
--- a/test/BundlerLocalTest.sol
+++ b/test/BundlerLocalTest.sol
@@ -260,7 +260,7 @@ contract BundlerLocalTest is LocalTest {
     }
 
     function testMissedReenterFails(bytes32 _hash) public {
-        vm.assum(_hash != bytes32(0));
+        vm.assume(_hash != bytes32(0));
         bundle.push(_call(adapterMock, abi.encodeCall(AdapterMock.emitInitiator, ()), 0, false, _hash));
         vm.expectRevert(ErrorsLib.MissingExpectedReenter.selector);
         bundler.multicall(bundle);


### PR DESCRIPTION
Add a test to properly check that missed reenters are caught. Previously this change was not caught by any test:

```diff
index d2536b27..353a1c39 100644
--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -63,7 +63,7 @@ contract Bundler is IBundler {
             (bool success, bytes memory returnData) = to.call{value: bundle[i].value}(bundle[i].data);
             if (!bundle[i].skipRevert && !success) UtilsLib.lowLevelRevert(returnData);
 
-            require(reenterHash == bytes32(0), ErrorsLib.MissingExpectedReenter());
         }
+        require(reenterHash == bytes32(0), ErrorsLib.MissingExpectedReenter());
     }
 }
 ```