### PR TITLE
fix: OZ N-05: change misleading error

### DIFF
--- a/src/adapters/ParaswapAdapter.sol
+++ b/src/adapters/ParaswapAdapter.sol
@@ -147,7 +147,7 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
         uint256 minDestAmount,
         address receiver
     ) internal {
-        require(AUGUSTUS_REGISTRY.isValidAugustus(augustus), ErrorsLib.AugustusNotInRegistry());
+        require(AUGUSTUS_REGISTRY.isValidAugustus(augustus), ErrorsLib.InvalidAugustus());
         require(receiver != address(0), ErrorsLib.ZeroAddress());
         require(minDestAmount != 0, ErrorsLib.ZeroAmount());
 

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -59,8 +59,8 @@ library ErrorsLib {
 
     /* PARASWAP ADAPTER */
 
-    /// @dev Thrown when contract used to trade is not in the paraswap registry.
-    error AugustusNotInRegistry();
+    /// @dev Thrown when the contract used to trade is not deemed valid by Paraswap's Augustus registry.
+    error InvalidAugustus();
 
     /// @dev Thrown when a data offset is invalid.
     error InvalidOffset();

--- a/test/ParaswapAdapterLocalTest.sol
+++ b/test/ParaswapAdapterLocalTest.sol
@@ -48,7 +48,7 @@ contract ParaswapAdapterLocalTest is LocalTest {
 
         vm.prank(address(bundler));
 
-        vm.expectRevert(ErrorsLib.AugustusNotInRegistry.selector);
+        vm.expectRevert(ErrorsLib.InvalidAugustus.selector);
         paraswapAdapter.sell(_augustus, new bytes(32), address(0), address(0), false, Offsets(0, 0, 0), address(0));
     }
 
@@ -57,7 +57,7 @@ contract ParaswapAdapterLocalTest is LocalTest {
 
         vm.prank(address(bundler));
 
-        vm.expectRevert(ErrorsLib.AugustusNotInRegistry.selector);
+        vm.expectRevert(ErrorsLib.InvalidAugustus.selector);
         paraswapAdapter.buy(_augustus, new bytes(32), address(0), address(0), 0, Offsets(0, 0, 0), address(0));
     }
 


### PR DESCRIPTION
Fix finding [N-05](https://defender.openzeppelin.com/#/audit/6ae42791-008e-4c8d-aedf-825c22de141a/issues/N-05).

> When executing a swap in the ParaswapAdapter contract, the function will [check whether the passed augustus address is valid](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L150) and revert with the AugustusNotInRegistry custom error if the address is invalid. This suggests that the passed augustus address is not in the registry. However, the isAugustusValid function in the AugustusRegistry contract will return false if the address is not in the registry or is banned.
>
> Consider renaming the custom error to InvalidAugustus to better reflect validation failure.