### PR TITLE
fix: OZ N-06: remove unused state variable

### DIFF
--- a/src/adapters/EthereumGeneralAdapter1.sol
+++ b/src/adapters/EthereumGeneralAdapter1.sol
@@ -14,9 +14,6 @@ contract EthereumGeneralAdapter1 is GeneralAdapter1 {
 
     /* IMMUTABLES */
 
-    /// @dev The address of the DAI token.
-    address public immutable DAI;
-
     /// @dev The address of the stETH token.
     address public immutable ST_ETH;
 
@@ -34,7 +31,6 @@ contract EthereumGeneralAdapter1 is GeneralAdapter1 {
     /// @param bundler The address of the bundler.
     /// @param morpho The address of Morpho.
     /// @param weth The address of the WETH token.
-    /// @param dai The address of the DAI token.
     /// @param wStEth The address of the wstETH token.
     /// @param morphoToken The address of the MORPHO token.
     /// @param morphoWrapper The address of the MORPHO token wrapper.
@@ -42,17 +38,14 @@ contract EthereumGeneralAdapter1 is GeneralAdapter1 {
         address bundler,
         address morpho,
         address weth,
-        address dai,
         address wStEth,
         address morphoToken,
         address morphoWrapper
     ) GeneralAdapter1(bundler, morpho, weth) {
-        require(dai != address(0), ErrorsLib.ZeroAddress());
         require(wStEth != address(0), ErrorsLib.ZeroAddress());
         require(morphoToken != address(0), ErrorsLib.ZeroAddress());
         require(morphoWrapper != address(0), ErrorsLib.ZeroAddress());
 
-        DAI = dai;
         ST_ETH = IWstEth(wStEth).stETH();
         WST_ETH = wStEth;
         MORPHO_TOKEN = morphoToken;

--- a/test/fork/PermitAdapterForkTest.sol
+++ b/test/fork/PermitAdapterForkTest.sol
@@ -64,7 +64,6 @@ contract PermitAdapterForkTest is ForkTest {
     {
         address user = vm.addr(privateKey);
         uint256 nonce = IDaiPermit(DAI).nonces(user);
-        require(DAI == ethereumGeneralAdapter1.DAI(), "not the same DAI");
 
         uint8 v;
         bytes32 r;

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -33,7 +33,6 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
                 address(bundler),
                 address(morpho),
                 getAddress("WETH"),
-                getAddress("DAI"),
                 getAddress("WST_ETH"),
                 getAddress("MORPHO_TOKEN"),
                 getAddress("MORPHO_WRAPPER")


### PR DESCRIPTION
(Already addressed in #176, this PR is for bookeeping.)

Fix finding [N-06](https://defender.openzeppelin.com/#/audit/6ae42791-008e-4c8d-aedf-825c22de141a/issues/N-06).

> Within the EthereumGeneralAdapter1 contract, the [DAI state variable](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/EthereumGeneralAdapter1.sol#L18) is unused.
>
> To improve the overall clarity and intent of the codebase, consider removing any unused state variables.