### PR TITLE
fix: OZ N-08: remove unnecessary check

### DIFF
--- a/src/adapters/ParaswapAdapter.sol
+++ b/src/adapters/ParaswapAdapter.sol
@@ -168,7 +168,7 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
         require(srcAmount <= maxSrcAmount, ErrorsLib.SellAmountTooHigh());
         require(destAmount >= minDestAmount, ErrorsLib.BuyAmountTooLow());
 
-        if (destAmount > 0 && receiver != address(this)) {
+        if (receiver != address(this)) {
             SafeERC20.safeTransfer(IERC20(destToken), receiver, destAmount);
         }
     }


### PR DESCRIPTION
(Already addressed in https://github.com/morpho-org/bundler-v3/pull/176, this PR is for bookeeping.)

Fix finding [N-08](https://defender.openzeppelin.com/#/audit/6ae42791-008e-4c8d-aedf-825c22de141a/issues/N-08). Note that the finding is unclear on whether the `receiver != address(this)` check should be removed. It should not be removed. Only the `destAmount > 0` check should be removed.

> The [swap function](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L141) of the ParaswapAdapter contract executes a swap with the defined augustus contract. At the end of the swap, the function transfers the remaining destAmount of the destToken to the defined receiver [if the destAmount is larger than zero and the receiver is not the address of the ParaswapAdapter contract](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L171).
>
> However, the [minDestAmount is guaranteed to be larger than zero](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L152) and [destAmount can only be either equal or greater than minDestAmount](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L169). This means that the destAmount is guaranteed to be larger than zero, making the destAmount > 0 && receiver check in [line 171](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L171) unnecessary.
>
> Consider removing the destAmount > 0 && receiver check in [line 171](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L171) to make the code more concise and save gas by avoiding unnecessary checks.