### PR TITLE
fix: OZ N-09: Add docs on augustus compatiblity

### DIFF
--- a/src/adapters/ParaswapAdapter.sol
+++ b/src/adapters/ParaswapAdapter.sol
@@ -35,8 +35,7 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     /* SWAP ACTIONS */
 
     /// @notice Sells an exact amount. Can check for a minimum purchased amount.
-    /// @notice The `augustus` parameter exists to accomodate future Paraswap updates but compatibility is not
-    /// guaranteed.
+    /// @notice Compatibility with Augustus versions different from 6.2 is not guaranteed.
     /// @param augustus Address of the swapping contract. Must be in Paraswap's Augustus registry.
     /// @param callData Swap data to call `augustus` with. Contains routing information.
     /// @param srcToken Token to sell.
@@ -72,8 +71,7 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     }
 
     /// @notice Buys an exact amount. Can check for a maximum sold amount.
-    /// @notice The `augustus` parameter exists to accomodate future Paraswap updates but compatibility is not
-    /// guaranteed.
+    /// @notice Compatibility with Augustus versions different from 6.2 is not guaranteed.
     /// @param augustus Address of the swapping contract. Must be in Paraswap's Augustus registry.
     /// @param callData Swap data to call `augustus`. Contains routing information.
     /// @dev `callData` can change if `marketParams.loanToken == destToken`.
@@ -110,6 +108,7 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     }
 
     /// @notice Buys an amount corresponding to a user's Morpho debt.
+    /// @notice Compatibility with Augustus versions different from 6.2 is not guaranteed.
     /// @param augustus Address of the swapping contract. Must be in Paraswap's Augustus registry.
     /// @param callData Swap data to call `augustus`. Contains routing information.
     /// @param srcToken Token to sell.


### PR DESCRIPTION
Fix finding [N-09](https://defender.openzeppelin.com/#/audit/6ae42791-008e-4c8d-aedf-825c22de141a/issues/N-09).

> The [ParaswapAdapter](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol) contract is an adapter that facilitates swaps on Paraswap's Augustus contract. ParaswapAdapter is built to work with the latest version (v6) of the Augustus contract. The [Augusutus contract address](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L48) is provided by the user when executing swaps. The user can, however, unknowingly provide the address of an older or a future/newer version of Augustus which can result in unwanted scenarios. This is because ParaswapAdapter is not necessarily compatible with other versions of Augustus.

> Consider adding a docstring stating the Augustus version which the ParaswapAdapter is designed to interact with.