### PR TITLE
fix: OZ N-10: fix docs & require nonzero debt bought

### DIFF
--- a/src/adapters/CoreAdapter.sol
+++ b/src/adapters/CoreAdapter.sol
@@ -42,7 +42,6 @@ abstract contract CoreAdapter {
     /* ACTIONS */
 
     /// @notice Transfers native assets.
-    /// @dev The amount transfered can be zero.
     /// @param receiver The address that will receive the native tokens.
     /// @param amount The amount of native tokens to transfer. Pass `type(uint).max` to transfer the adapter's balance.
     function nativeTransfer(address receiver, uint256 amount) external onlyBundler {
@@ -57,7 +56,6 @@ abstract contract CoreAdapter {
     }
 
     /// @notice Transfers ERC20 tokens.
-    /// @dev The amount transfered can be zero.
     /// @param token The address of the ERC20 token to transfer.
     /// @param receiver The address that will receive the tokens.
     /// @param amount The amount of token to transfer. Pass `type(uint).max` to transfer the adapter's balance.

--- a/src/adapters/GeneralAdapter1.sol
+++ b/src/adapters/GeneralAdapter1.sol
@@ -394,7 +394,6 @@ contract GeneralAdapter1 is CoreAdapter {
 
     /// @notice Transfers ERC20 tokens from the initiator.
     /// @notice Initiator must have given sufficient allowance to the Adapter to spend their tokens.
-    /// @notice The amount must be strictly positive.
     /// @param token The address of the ERC20 token to transfer.
     /// @param receiver The address that will receive the tokens.
     /// @param amount The amount of token to transfer. Pass `type(uint).max` to transfer the initiator's balance.

--- a/src/adapters/ParaswapAdapter.sol
+++ b/src/adapters/ParaswapAdapter.sol
@@ -72,7 +72,6 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     /// @notice Buys an exact amount. Can check for a maximum sold amount.
     /// @param augustus Address of the swapping contract. Must be in Paraswap's Augustus registry.
     /// @param callData Swap data to call `augustus`. Contains routing information.
-    /// @dev `callData` can change if `marketParams.loanToken == destToken`.
     /// @param srcToken Token to sell.
     /// @param destToken Token to buy.
     /// @param newDestAmount Adjusted amount to buy. Will be used to update callData before sent to Augustus contract.
@@ -109,7 +108,7 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     /// @param augustus Address of the swapping contract. Must be in Paraswap's Augustus registry.
     /// @param callData Swap data to call `augustus`. Contains routing information.
     /// @param srcToken Token to sell.
-    /// @param marketParams Market parameters of the market with Morpho debt.
+    /// @param marketParams Market parameters of the market with Morpho debt. The user must have nonzero debt.
     /// @param offsets Offsets in callData of the exact buy amount (`exactAmount`), maximum sell amount (`limitAmount`)
     /// and quoted sell amount (`quotedAmount`).
     /// @param onBehalf The amount bought will be exactly `onBehalf`'s debt.
@@ -124,6 +123,7 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
         address receiver
     ) external {
         uint256 debtAmount = MorphoBalancesLib.expectedBorrowAssets(MORPHO, marketParams, onBehalf);
+        require(debtAmount != 0, ErrorsLib.ZeroAmount());
         buy({
             augustus: augustus,
             callData: callData,


### PR DESCRIPTION
(Partially already addressed in https://github.com/morpho-org/bundler-v3/pull/176)

Fix finding [N-10](https://defender.openzeppelin.com/#/audit/6ae42791-008e-4c8d-aedf-825c22de141a/issues/N-10).

> Throughout the codebase, multiple instances of misleading documentation were identified:
>
> Both comments in lines [45](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/CoreAdapter.sol#L45) and [60](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/CoreAdapter.sol#L60) for the nativeTransfer and erc20Transfer functions suggest that an amount of zero can be transferred. However, both functions require the amount to be different from zero [[1]](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/CoreAdapter.sol#L54) [[2]](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/CoreAdapter.sol#L70).
The comment in [line 75](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L75) of the ParaswapAdapter contract suggests that callData can change if marketParams.loanToken == destToken, which does not occur inside the function.
> Consider updating the above-mentioned comments to improve the clarity of the codebase.
>
> In addition, the comment in [line 108](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L108) of the ParaswapAdapter contract implies that the buyMorphoDept function buys an amount corresponding to a user's Morpho debt. However, in case the [debtAmount](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L126) is zero, the function will still execute the buy function using the values inside the callData.
>
> Consider either returning early if the user has no debtAmount or updating the function's documentation accordingly.