### PR TITLE
fix: OZ L-01: explain src token skimming

### DIFF
--- a/src/adapters/ParaswapAdapter.sol
+++ b/src/adapters/ParaswapAdapter.sol
@@ -43,7 +43,8 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     /// @param offsets Offsets in callData of the exact sell amount (`exactAmount`), minimum buy amount (`limitAmount`)
     /// and quoted buy amount (`quotedAmount`).
     /// @dev The quoted buy amount will change only if its offset is not zero.
-    /// @param receiver Address to which bought assets will be sent. Any leftover `srcToken` should be skimmed separately.
+    /// @param receiver Address to which bought assets will be sent. Any leftover `srcToken` should be skimmed
+    /// separately.
     function sell(
         address augustus,
         bytes memory callData,
@@ -113,7 +114,8 @@ contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     /// @param offsets Offsets in callData of the exact buy amount (`exactAmount`), maximum sell amount (`limitAmount`)
     /// and quoted sell amount (`quotedAmount`).
     /// @param onBehalf The amount bought will be exactly `onBehalf`'s debt.
-    /// @param receiver Address to which bought assets will be sent. Any leftover `src` tokens should be skimmed separately.
+    /// @param receiver Address to which bought assets will be sent. Any leftover `src` tokens should be skimmed
+    /// separately.
     function buyMorphoDebt(
         address augustus,
         bytes memory callData,


### PR DESCRIPTION
Addresses finding [L-01](https://defender.openzeppelin.com/#/audit/6ae42791-008e-4c8d-aedf-825c22de141a/issues/L-01).

Behavior of the adapter is kept the same because skimming may still be necessary if the paraswap adapter received more tokens that it was about to sell, and because selling fewer tokens that expected is positive for the user.

Added comments to clarify.

> In ParaswapAdapter, the [sell function](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L47) is used to sell an exact amount of srcToken. It can also check for a minimum purchased amount of destToken. Its complementary function, the [buy function](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L84), is used to buy an exact amount of destToken and can also check for a maximum sold amount of srcToken. Both of these functions leverage the swap function [[1]](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L61-L69) [[2]](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L97-L105) to execute the defined swap using an augustus contract.
>
> However, for the sell function, the swap function will only [guarantee that the srcAmount sold is either less than or equal to the maxSrcAmount](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L168) but not strictly equal, meaning the function does not guarantee the exact amount sold. Similarly, for the buy function, the swap function will only [guarantee that the destAmount bought is either bigger than or equal to the minDestAmount](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L169) but not strictly equal, meaning the function does not guarantee the exact amount bought.
>
> For example, if a user sends an amount of srcToken to the contract and [wants to sell all the balance they transferred](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L56-L59), they might expect that at the end of the transaction, the srcToken balance of the ParaswapAdapter is zero, skipping the sweeping action. However, if the underlying augustus contract misbehaves, passing the [checks](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L168-L169) in the swap function, it is possible that some srcToken balance is left in the contract, leaving an opportunity for a malicious actor to back-run the transaction and sweep the tokens after the transaction. A similar behavior is allowed when buying tokens.
>
> Consider adjusting the balance checks to the exact amounts specified when selling or buying, respectively. Doing this will help prevent unexpected remaining funds in the ParaswapAdapter contract. Alternatively, consider removing the word [exact](https://github.com/morpho-org/bundler-v3/blob/d7940c994c6dbce5cc682032352befb1288cc7b9/src/adapters/ParaswapAdapter.sol#L37) from the docstrings in the adapter.