### PR TITLE
fix: OZ N-02: update security contact natspec

### DIFF
--- a/src/Bundler.sol
+++ b/src/Bundler.sol
@@ -6,7 +6,7 @@ import {IBundler, Call} from "./interfaces/IBundler.sol";
 import {ErrorsLib} from "./libraries/ErrorsLib.sol";
 import {UtilsLib} from "./libraries/UtilsLib.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Enables batching multiple calls in a single one.
 /// @notice Transiently stores the initiator of the multicall.
 /// @notice Can be reentered by the last unreturned callee with known data.

--- a/src/adapters/CoreAdapter.sol
+++ b/src/adapters/CoreAdapter.sol
@@ -7,7 +7,7 @@ import {Address} from "../../lib/openzeppelin-contracts/contracts/utils/Address.
 import {IBundler} from "../interfaces/IBundler.sol";
 import {UtilsLib} from "../libraries/UtilsLib.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Common contract to all Bundler adapters.
 abstract contract CoreAdapter {
     /* IMMUTABLES */

--- a/src/adapters/EthereumGeneralAdapter1.sol
+++ b/src/adapters/EthereumGeneralAdapter1.sol
@@ -7,7 +7,7 @@ import {IStEth} from "../interfaces/IStEth.sol";
 import {GeneralAdapter1, ErrorsLib, ERC20Wrapper, UtilsLib, SafeERC20, IERC20} from "./GeneralAdapter1.sol";
 import {MathRayLib} from "../libraries/MathRayLib.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Adapter contract specific to Ethereum n°1.
 contract EthereumGeneralAdapter1 is GeneralAdapter1 {
     using MathRayLib for uint256;

--- a/src/adapters/GeneralAdapter1.sol
+++ b/src/adapters/GeneralAdapter1.sol
@@ -15,7 +15,7 @@ import {MorphoBalancesLib} from "../../lib/morpho-blue/src/libraries/periphery/M
 import {MarketParamsLib} from "../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
 import {MorphoLib} from "../../lib/morpho-blue/src/libraries/periphery/MorphoLib.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Chain agnostic adapter contract n°1.
 contract GeneralAdapter1 is CoreAdapter {
     using SafeCast160 for uint256;

--- a/src/adapters/ParaswapAdapter.sol
+++ b/src/adapters/ParaswapAdapter.sol
@@ -8,7 +8,7 @@ import {BytesLib} from "../libraries/BytesLib.sol";
 import {Math} from "../../lib/openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {IMorpho, MorphoBalancesLib} from "../../lib/morpho-blue/src/libraries/periphery/MorphoBalancesLib.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Adapter for trading with Paraswap.
 contract ParaswapAdapter is CoreAdapter, IParaswapAdapter {
     using Math for uint256;

--- a/src/adapters/migration/AaveV2MigrationAdapter.sol
+++ b/src/adapters/migration/AaveV2MigrationAdapter.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {IAaveV2} from "../../interfaces/IAaveV2.sol";
 import {CoreAdapter, ErrorsLib, IERC20, UtilsLib} from "../CoreAdapter.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Contract allowing to migrate a position from Aave V2 to Morpho easily.
 contract AaveV2MigrationAdapter is CoreAdapter {
     /* IMMUTABLES */

--- a/src/adapters/migration/AaveV3MigrationAdapter.sol
+++ b/src/adapters/migration/AaveV3MigrationAdapter.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {IAaveV3} from "../../interfaces/IAaveV3.sol";
 import {CoreAdapter, ErrorsLib, IERC20, UtilsLib} from "../CoreAdapter.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Contract allowing to migrate a position from Aave V3 to Morpho easily.
 contract AaveV3MigrationAdapter is CoreAdapter {
     /* IMMUTABLES */

--- a/src/adapters/migration/AaveV3OptimizerMigrationAdapter.sol
+++ b/src/adapters/migration/AaveV3OptimizerMigrationAdapter.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {IAaveV3Optimizer} from "../../interfaces/IAaveV3Optimizer.sol";
 import {CoreAdapter, ErrorsLib, IERC20, UtilsLib} from "../CoreAdapter.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Contract allowing to migrate a position from AaveV3 Optimizer to Morpho easily.
 contract AaveV3OptimizerMigrationAdapter is CoreAdapter {
     /* IMMUTABLES */

--- a/src/adapters/migration/CompoundV2MigrationAdapter.sol
+++ b/src/adapters/migration/CompoundV2MigrationAdapter.sol
@@ -9,7 +9,7 @@ import {MathLib} from "../../../lib/morpho-blue/src/libraries/MathLib.sol";
 
 import {CoreAdapter, ErrorsLib, IERC20, SafeERC20, UtilsLib, Address} from "../CoreAdapter.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Contract allowing to migrate a position from Compound V2 to Morpho easily.
 contract CompoundV2MigrationAdapter is CoreAdapter {
     /* IMMUTABLES */

--- a/src/adapters/migration/CompoundV3MigrationAdapter.sol
+++ b/src/adapters/migration/CompoundV3MigrationAdapter.sol
@@ -6,7 +6,7 @@ import {ICompoundV3} from "../../interfaces/ICompoundV3.sol";
 import {Math} from "../../../lib/morpho-utils/src/math/Math.sol";
 import {CoreAdapter, ErrorsLib, IERC20, UtilsLib} from "../CoreAdapter.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Contract allowing to migrate a position from Compound V3 to Morpho easily.
 contract CompoundV3MigrationAdapter is CoreAdapter {
     /* CONSTRUCTOR */

--- a/src/interfaces/IBundler.sol
+++ b/src/interfaces/IBundler.sol
@@ -11,7 +11,7 @@ struct Call {
     bytes32 callbackHash;
 }
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 interface IBundler {
     function multicall(Call[] calldata) external payable;
     function reenter(Call[] calldata) external;

--- a/src/interfaces/IParaswapAdapter.sol
+++ b/src/interfaces/IParaswapAdapter.sol
@@ -14,7 +14,7 @@ struct Offsets {
     uint256 quotedAmount;
 }
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Interface of Paraswap Adapter.
 interface IParaswapAdapter {
     function sell(

--- a/src/libraries/BytesLib.sol
+++ b/src/libraries/BytesLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {ErrorsLib} from "./ErrorsLib.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Library exposing bytes manipulation.
 library BytesLib {
     /// @notice Reads 32 bytes at offset `offset` of memory bytes `data`.

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Library exposing error messages.
 library ErrorsLib {
     /* STANDARD ADAPTERS */

--- a/src/libraries/MathRayLib.sol
+++ b/src/libraries/MathRayLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 uint256 constant RAY = 1e27;
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Library to manage high-precision fixed-point arithmetic.
 library MathRayLib {
     /// @dev Returns (`x` * `RAY`) / `y` rounded down.

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {SafeERC20, IERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 
-/// @custom:contact security@morpho.org
+/// @custom:security-contact security@morpho.org
 /// @notice Utils library.
 library UtilsLib {
     /// @dev Gives the max approval to `spender` to spend the given token.


### PR DESCRIPTION
Fix finding [N-02](https://defender.openzeppelin.com/#/audit/6ae42791-008e-4c8d-aedf-825c22de141a/issues/N-02).

> Throughout the codebase, multiple instances of the security contact tag being used incorrectly were identified.
>
> Consider replacing all occurrences of @custom:contact with the recommended @custom:security-contact tag as it has been adopted by the [OpenZeppelin Wizard](https://wizard.openzeppelin.com/) and the [ethereum-lists](https://github.com/ethereum-lists/contracts#tracking-new-deployments).
