### PR TITLE
Rename `transferFrom2` into `permit2TransferFrom`

### DIFF
--- a/src/adapters/GeneralAdapter1.sol
+++ b/src/adapters/GeneralAdapter1.sol
@@ -394,7 +394,7 @@ contract GeneralAdapter1 is CoreAdapter {
     /// @param token The address of the ERC20 token to transfer.
     /// @param receiver The address that will receive the tokens.
     /// @param amount The amount of token to transfer. Pass `type(uint).max` to transfer the initiator's balance.
-    function transferFrom2(address token, address receiver, uint256 amount) external onlyBundler {
+    function permit2TransferFrom(address token, address receiver, uint256 amount) external onlyBundler {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         address initiator = initiator();

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -31,7 +31,7 @@ contract Permit2AdapterForkTest is ForkTest {
         MarketParams memory marketParams = _randomMarketParams(seed);
 
         bundle.push(_approve2(privateKey, marketParams.loanToken, amount, 0, false));
-        bundle.push(_transferFrom2(marketParams.loanToken, amount));
+        bundle.push(_permit2TransferFrom(marketParams.loanToken, amount));
         bundle.push(_morphoSupply(marketParams, amount, 0, type(uint256).max, onBehalf, hex""));
 
         uint256 collateralBalanceBefore = IERC20(marketParams.collateralToken).balanceOf(onBehalf);
@@ -189,15 +189,15 @@ contract Permit2AdapterForkTest is ForkTest {
         bundler.multicall(bundle);
     }
 
-    function testTransferFrom2ZeroAmount() public {
-        bundle.push(_transferFrom2(DAI, 0));
+    function testPermit2TransferFromZeroAmount() public {
+        bundle.push(_permit2TransferFrom(DAI, 0));
 
         vm.expectRevert(ErrorsLib.ZeroAmount.selector);
         bundler.multicall(bundle);
     }
 
-    function testTransferFrom2Unauthorized() public {
+    function testPermit2TransferFromUnauthorized() public {
         vm.expectRevert(ErrorsLib.UnauthorizedSender.selector);
-        generalAdapter1.transferFrom2(address(0), address(0), 0);
+        generalAdapter1.permit2TransferFrom(address(0), address(0), 0);
     }
 }

--- a/test/fork/StEthAdapterForkTest.sol
+++ b/test/fork/StEthAdapterForkTest.sol
@@ -85,7 +85,7 @@ contract EthereumStEthAdapterForkTest is ForkTest {
         amount = IERC20(ST_ETH).balanceOf(user);
 
         bundle.push(_approve2(privateKey, ST_ETH, amount, 0, false));
-        bundle.push(_transferFrom2(ST_ETH, address(ethereumGeneralAdapter1), amount));
+        bundle.push(_permit2TransferFrom(ST_ETH, address(ethereumGeneralAdapter1), amount));
         bundle.push(_wrapStEth(amount, RECEIVER));
 
         uint256 wstEthExpectedAmount = IStEth(ST_ETH).getSharesByPooledEth(IERC20(ST_ETH).balanceOf(user));
@@ -126,7 +126,7 @@ contract EthereumStEthAdapterForkTest is ForkTest {
         amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
 
         bundle.push(_approve2(privateKey, WST_ETH, amount, 0, false));
-        bundle.push(_transferFrom2(WST_ETH, address(ethereumGeneralAdapter1), amount));
+        bundle.push(_permit2TransferFrom(WST_ETH, address(ethereumGeneralAdapter1), amount));
         bundle.push(_unwrapStEth(amount, RECEIVER));
 
         deal(WST_ETH, user, amount);

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -168,12 +168,16 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
         );
     }
 
-    function _transferFrom2(address asset, uint256 amount) internal view returns (Call memory) {
-        return _transferFrom2(asset, address(generalAdapter1), amount);
+    function _permit2TransferFrom(address asset, uint256 amount) internal view returns (Call memory) {
+        return _permit2TransferFrom(asset, address(generalAdapter1), amount);
     }
 
-    function _transferFrom2(address asset, address receiver, uint256 amount) internal view returns (Call memory) {
-        return _call(generalAdapter1, abi.encodeCall(GeneralAdapter1.transferFrom2, (asset, receiver, amount)));
+    function _permit2TransferFrom(address asset, address receiver, uint256 amount)
+        internal
+        view
+        returns (Call memory)
+    {
+        return _call(generalAdapter1, abi.encodeCall(GeneralAdapter1.permit2TransferFrom, (asset, receiver, amount)));
     }
 
     /* STAKE ACTIONS */

--- a/test/fork/migration/AaveV2MigrationAdapterForkTest.sol
+++ b/test/fork/migration/AaveV2MigrationAdapterForkTest.sol
@@ -115,7 +115,7 @@ contract AaveV2MigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_aaveV2Repay(marketParams.loanToken, borrowed / 2, user));
         callbackBundle.push(_aaveV2Repay(marketParams.loanToken, type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        callbackBundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         callbackBundle.push(_aaveV2Withdraw(marketParams.collateralToken, collateralSupplied, address(generalAdapter1)));
 
         bundle.push(_morphoSupplyCollateral(marketParams, collateralSupplied, user, abi.encode(callbackBundle)));
@@ -155,7 +155,7 @@ contract AaveV2MigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_aaveV2Repay(marketParams.loanToken, borrowed / 2, user));
         callbackBundle.push(_aaveV2Repay(marketParams.loanToken, type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        callbackBundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         callbackBundle.push(_aaveV2Withdraw(DAI, collateralSupplied, address(generalAdapter1)));
         callbackBundle.push(_erc4626Deposit(S_DAI, collateralSupplied, type(uint256).max, address(generalAdapter1)));
 
@@ -201,7 +201,7 @@ contract AaveV2MigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_aaveV2Repay(marketParams.loanToken, borrowed / 2, user));
         callbackBundle.push(_aaveV2Repay(marketParams.loanToken, type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, aToken, type(uint160).max, 0, false));
-        callbackBundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         callbackBundle.push(_aaveV2Withdraw(ST_ETH, type(uint256).max, address(ethereumGeneralAdapter1)));
         callbackBundle.push(_wrapStEth(type(uint256).max, address(generalAdapter1)));
 
@@ -232,7 +232,7 @@ contract AaveV2MigrationAdapterForkTest is MigrationForkTest {
         IERC20(aToken).forceApprove(address(Permit2Lib.PERMIT2), aTokenBalance);
 
         bundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        bundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        bundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         bundle.push(_aaveV2Withdraw(marketParams.loanToken, supplied, address(generalAdapter1)));
         bundle.push(_morphoSupply(marketParams, supplied, 0, type(uint256).max, user, hex""));
 
@@ -261,7 +261,7 @@ contract AaveV2MigrationAdapterForkTest is MigrationForkTest {
         IERC20(aToken).forceApprove(address(Permit2Lib.PERMIT2), aTokenBalance);
 
         bundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        bundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        bundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         bundle.push(_aaveV2Withdraw(marketParams.loanToken, supplied, address(generalAdapter1)));
         bundle.push(_erc4626Deposit(address(suppliersVault), supplied, type(uint256).max, user));
 

--- a/test/fork/migration/AaveV3MigrationAdapterForkTest.sol
+++ b/test/fork/migration/AaveV3MigrationAdapterForkTest.sol
@@ -154,7 +154,7 @@ contract AaveV3MigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_aaveV3Repay(marketParams.loanToken, borrowed / 2, user));
         callbackBundle.push(_aaveV3Repay(marketParams.loanToken, type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        callbackBundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         callbackBundle.push(_aaveV3Withdraw(marketParams.collateralToken, collateralSupplied, address(generalAdapter1)));
 
         bundle.push(_morphoSupplyCollateral(marketParams, collateralSupplied, user, abi.encode(callbackBundle)));
@@ -195,7 +195,7 @@ contract AaveV3MigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_aaveV3Repay(marketParams.loanToken, borrowed / 2, user));
         callbackBundle.push(_aaveV3Repay(marketParams.loanToken, type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        callbackBundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         callbackBundle.push(_aaveV3Withdraw(USDT, amountUsdt, address(generalAdapter1)));
 
         bundle.push(_morphoSupplyCollateral(marketParams, amountUsdt, user, abi.encode(callbackBundle)));
@@ -251,7 +251,7 @@ contract AaveV3MigrationAdapterForkTest is MigrationForkTest {
         IERC20(aToken).forceApprove(address(Permit2Lib.PERMIT2), aTokenBalance);
 
         bundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        bundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        bundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         bundle.push(_aaveV3Withdraw(marketParams.loanToken, supplied, address(generalAdapter1)));
         bundle.push(_morphoSupply(marketParams, supplied, 0, type(uint256).max, user, hex""));
 
@@ -306,7 +306,7 @@ contract AaveV3MigrationAdapterForkTest is MigrationForkTest {
         IERC20(aToken).forceApprove(address(Permit2Lib.PERMIT2), aTokenBalance);
 
         bundle.push(_approve2(privateKey, aToken, uint160(aTokenBalance), 0, false));
-        bundle.push(_transferFrom2(aToken, address(migrationAdapter), aTokenBalance));
+        bundle.push(_permit2TransferFrom(aToken, address(migrationAdapter), aTokenBalance));
         bundle.push(_aaveV3Withdraw(marketParams.loanToken, supplied, address(generalAdapter1)));
         bundle.push(_erc4626Deposit(address(suppliersVault), supplied, type(uint256).max, user));
 

--- a/test/fork/migration/CompoundV2ERC20MigrationAdapterForkTest.sol
+++ b/test/fork/migration/CompoundV2ERC20MigrationAdapterForkTest.sol
@@ -111,7 +111,7 @@ contract CompoundV2ERC20MigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_compoundV2RepayErc20(C_USDC_V2, borrowed / 2, user));
         callbackBundle.push(_compoundV2RepayErc20(C_USDC_V2, type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, C_DAI_V2, uint160(cTokenBalance), 0, false));
-        callbackBundle.push(_transferFrom2(C_DAI_V2, address(migrationAdapter), cTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(C_DAI_V2, address(migrationAdapter), cTokenBalance));
         callbackBundle.push(_compoundV2RedeemErc20(C_DAI_V2, cTokenBalance, address(generalAdapter1)));
 
         bundle.push(_morphoSupplyCollateral(marketParams, collateral, user, abi.encode(callbackBundle)));
@@ -181,7 +181,7 @@ contract CompoundV2ERC20MigrationAdapterForkTest is MigrationForkTest {
         IERC20(C_USDC_V2).forceApprove(address(Permit2Lib.PERMIT2), cTokenBalance);
 
         bundle.push(_approve2(privateKey, C_USDC_V2, uint160(cTokenBalance), 0, false));
-        bundle.push(_transferFrom2(C_USDC_V2, address(migrationAdapter), cTokenBalance));
+        bundle.push(_permit2TransferFrom(C_USDC_V2, address(migrationAdapter), cTokenBalance));
         bundle.push(_compoundV2RedeemErc20(C_USDC_V2, cTokenBalance, address(generalAdapter1)));
         bundle.push(_morphoSupply(marketParams, supplied, 0, type(uint256).max, user, hex""));
 
@@ -210,7 +210,7 @@ contract CompoundV2ERC20MigrationAdapterForkTest is MigrationForkTest {
         IERC20(C_USDC_V2).forceApprove(address(Permit2Lib.PERMIT2), cTokenBalance);
 
         bundle.push(_approve2(privateKey, C_USDC_V2, uint160(cTokenBalance), 0, false));
-        bundle.push(_transferFrom2(C_USDC_V2, address(migrationAdapter), cTokenBalance));
+        bundle.push(_permit2TransferFrom(C_USDC_V2, address(migrationAdapter), cTokenBalance));
         bundle.push(_compoundV2RedeemErc20(C_USDC_V2, cTokenBalance, address(generalAdapter1)));
         bundle.push(_erc4626Deposit(address(suppliersVault), supplied, type(uint256).max, user));
 

--- a/test/fork/migration/CompoundV2EthBorrowableMigrationAdapterForkTest.sol
+++ b/test/fork/migration/CompoundV2EthBorrowableMigrationAdapterForkTest.sol
@@ -151,7 +151,7 @@ contract CompoundV2EthBorrowableMigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_compoundV2RepayEth(borrowed / 2, user));
         callbackBundle.push(_compoundV2RepayEth(type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, C_DAI_V2, uint160(cTokenBalance), 0, false));
-        callbackBundle.push(_transferFrom2(C_DAI_V2, address(migrationAdapter), cTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(C_DAI_V2, address(migrationAdapter), cTokenBalance));
         callbackBundle.push(_compoundV2RedeemErc20(C_DAI_V2, cTokenBalance, address(generalAdapter1)));
 
         bundle.push(_morphoSupplyCollateral(marketParams, collateral, user, abi.encode(callbackBundle)));
@@ -179,7 +179,7 @@ contract CompoundV2EthBorrowableMigrationAdapterForkTest is MigrationForkTest {
         IERC20(C_ETH_V2).forceApprove(address(Permit2Lib.PERMIT2), cTokenBalance);
 
         bundle.push(_approve2(privateKey, C_ETH_V2, uint160(cTokenBalance), 0, false));
-        bundle.push(_transferFrom2(C_ETH_V2, address(migrationAdapter), cTokenBalance));
+        bundle.push(_permit2TransferFrom(C_ETH_V2, address(migrationAdapter), cTokenBalance));
         bundle.push(_compoundV2RedeemEth(cTokenBalance, address(generalAdapter1)));
         bundle.push(_wrapNativeNoFunding(supplied, address(generalAdapter1)));
         bundle.push(_morphoSupply(marketParams, supplied, 0, type(uint256).max, user, hex""));
@@ -207,7 +207,7 @@ contract CompoundV2EthBorrowableMigrationAdapterForkTest is MigrationForkTest {
         IERC20(C_ETH_V2).forceApprove(address(Permit2Lib.PERMIT2), cTokenBalance);
 
         bundle.push(_approve2(privateKey, C_ETH_V2, uint160(cTokenBalance), 0, false));
-        bundle.push(_transferFrom2(C_ETH_V2, address(migrationAdapter), cTokenBalance));
+        bundle.push(_permit2TransferFrom(C_ETH_V2, address(migrationAdapter), cTokenBalance));
         bundle.push(_compoundV2RedeemEth(cTokenBalance, address(generalAdapter1)));
         bundle.push(_wrapNativeNoFunding(supplied, address(generalAdapter1)));
         bundle.push(_erc4626Deposit(address(suppliersVault), supplied, type(uint256).max, user));

--- a/test/fork/migration/CompoundV2EthCollateralMigrationAdapterForkTest.sol
+++ b/test/fork/migration/CompoundV2EthCollateralMigrationAdapterForkTest.sol
@@ -145,7 +145,7 @@ contract CompoundV2EthCollateralMigrationAdapterForkTest is MigrationForkTest {
         callbackBundle.push(_compoundV2RepayErc20(C_DAI_V2, borrowed / 2, user));
         callbackBundle.push(_compoundV2RepayErc20(C_DAI_V2, type(uint256).max, user));
         callbackBundle.push(_approve2(privateKey, C_ETH_V2, uint160(cTokenBalance), 0, false));
-        callbackBundle.push(_transferFrom2(C_ETH_V2, address(migrationAdapter), cTokenBalance));
+        callbackBundle.push(_permit2TransferFrom(C_ETH_V2, address(migrationAdapter), cTokenBalance));
         callbackBundle.push(_compoundV2RedeemEth(cTokenBalance, address(generalAdapter1)));
         callbackBundle.push(_wrapNativeNoFunding(collateral, address(generalAdapter1)));
 


### PR DESCRIPTION
To avoid a clash with `Permit2Lib.transferFrom2`. See https://morpholabs.slack.com/archives/C02N7CZ088N/p1735566494121269