### PR TITLE
Revert on Permit2 transfers to initiator.

### DIFF
--- a/src/adapters/GeneralAdapter1.sol
+++ b/src/adapters/GeneralAdapter1.sol
@@ -398,6 +398,7 @@ contract GeneralAdapter1 is CoreAdapter {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         address initiator = initiator();
+        require(initiator != receiver, ErrorsLib.InitiatorSelfAddress());
         if (amount == type(uint256).max) amount = IERC20(token).balanceOf(initiator);
 
         require(amount != 0, ErrorsLib.ZeroAmount());

--- a/src/adapters/GeneralAdapter1.sol
+++ b/src/adapters/GeneralAdapter1.sol
@@ -398,7 +398,7 @@ contract GeneralAdapter1 is CoreAdapter {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
 
         address initiator = initiator();
-        require(initiator != receiver, ErrorsLib.InitiatorSelfAddress());
+        require(initiator != receiver, ErrorsLib.TransferInitiatorSelf());
         if (amount == type(uint256).max) amount = IERC20(token).balanceOf(initiator);
 
         require(amount != 0, ErrorsLib.ZeroAmount());

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -46,6 +46,9 @@ library ErrorsLib {
     /// @dev Thrown when a call to withdrawTo fails.
     error WithdrawFailed();
 
+    /// @dev Thrown when a call transfers tokens from the initiator to the initiator.
+    error InitiatorSelfAddress();
+
     /* MIGRATION ADAPTERS */
 
     /// @dev Thrown when repaying a CompoundV2 debt returns an error code.

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -47,7 +47,7 @@ library ErrorsLib {
     error WithdrawFailed();
 
     /// @dev Thrown when a call transfers tokens from the initiator to the initiator.
-    error InitiatorSelfAddress();
+    error TransferInitiatorSelf();
 
     /* MIGRATION ADAPTERS */
 

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -196,12 +196,6 @@ contract Permit2AdapterForkTest is ForkTest {
         bundler.multicall(bundle);
     }
 
-    function testPermit2TransferFromInitiatorSelf() public {
-        bundle.push(_permit2TransferFrom(DAI, GeneralAdapter1, 1));
-        vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);
-        bundler.multicall(bundle);
-    }
-
     function testPermit2TransferFromUnauthorized() public {
         vm.expectRevert(ErrorsLib.UnauthorizedSender.selector);
         generalAdapter1.permit2TransferFrom(address(0), address(0), 0);

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -196,6 +196,13 @@ contract Permit2AdapterForkTest is ForkTest {
         bundler.multicall(bundle);
     }
 
+    function testPermit2TransferFromSelfInitiator() public {
+        bundle.push(_permit2TransferFromInitiator(DAI, 1));
+
+        vm.expectRevert(ErrorsLib.ZeroAmount.selector);
+        bundler.multicall(bundle);
+    }
+
     function testPermit2TransferFromUnauthorized() public {
         vm.expectRevert(ErrorsLib.UnauthorizedSender.selector);
         generalAdapter1.permit2TransferFrom(address(0), address(0), 0);

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -196,6 +196,12 @@ contract Permit2AdapterForkTest is ForkTest {
         bundler.multicall(bundle);
     }
 
+    function testPermit2TransferFromInitiatorSelf() public {
+        bundle.push(_permit2TransferFrom(DAI, GeneralAdapter1, 1));
+        vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);
+        bundler.multicall(bundle);
+    }
+
     function testPermit2TransferFromUnauthorized() public {
         vm.expectRevert(ErrorsLib.UnauthorizedSender.selector);
         generalAdapter1.permit2TransferFrom(address(0), address(0), 0);

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -197,10 +197,12 @@ contract Permit2AdapterForkTest is ForkTest {
     }
 
     function testPermit2TransferFromSelfInitiator() public {
-        vm.assume(address(this) != address(0));
+        uint256 privateKey = _boundPrivateKey(pickUint());
+        address user = vm.addr(privateKey);
 
         bundle.push(_permit2TransferFromInitiator(DAI, 1));
 
+        vm.prank(user);
         vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);
         bundler.multicall(bundle);
     }

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -202,6 +202,7 @@ contract Permit2AdapterForkTest is ForkTest {
 
         bundle.push(_permit2TransferFromInitiator(DAI, 1));
 
+        vm.assume(user != address(0));
         vm.prank(user);
         vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);
         bundler.multicall(bundle);

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -197,14 +197,9 @@ contract Permit2AdapterForkTest is ForkTest {
     }
 
     function testPermit2TransferFromSelfInitiator() public {
-        uint256 privateKey = _boundPrivateKey(pickUint());
-        address user = vm.addr(privateKey);
-        vm.assume(user != address(0));
+        bundle.push(_permit2TransferFrom(DAI, address(this), 1));
 
-        bundle.push(_permit2TransferFrom(DAI, user, 1));
-
-        vm.prank(user);
-        vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);
+        vm.expectRevert(ErrorsLib.TransferInitiatorSelf.selector);
         bundler.multicall(bundle);
     }
 

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -197,7 +197,7 @@ contract Permit2AdapterForkTest is ForkTest {
     }
 
     function testPermit2TransferFromSelfInitiator() public {
-        vm.assume(bundler.initiator() != address(0));
+        vm.assume(address(this) != address(0));
 
         bundle.push(_permit2TransferFromInitiator(DAI, 1));
 

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -197,6 +197,8 @@ contract Permit2AdapterForkTest is ForkTest {
     }
 
     function testPermit2TransferFromSelfInitiator() public {
+        vm.assume(bundler.initiator() != address(0));
+
         bundle.push(_permit2TransferFromInitiator(DAI, 1));
 
         vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -199,10 +199,10 @@ contract Permit2AdapterForkTest is ForkTest {
     function testPermit2TransferFromSelfInitiator() public {
         uint256 privateKey = _boundPrivateKey(pickUint());
         address user = vm.addr(privateKey);
-
-        bundle.push(_permit2TransferFromInitiator(DAI, 1));
-
         vm.assume(user != address(0));
+
+        bundle.push(_permit2TransferFrom(DAI, user, 1));
+
         vm.prank(user);
         vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);
         bundler.multicall(bundle);

--- a/test/fork/Permit2AdapterForkTest.sol
+++ b/test/fork/Permit2AdapterForkTest.sol
@@ -199,7 +199,7 @@ contract Permit2AdapterForkTest is ForkTest {
     function testPermit2TransferFromSelfInitiator() public {
         bundle.push(_permit2TransferFromInitiator(DAI, 1));
 
-        vm.expectRevert(ErrorsLib.ZeroAmount.selector);
+        vm.expectRevert(ErrorsLib.InitiatorSelfAddress.selector);
         bundler.multicall(bundle);
     }
 

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -168,10 +168,6 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
         );
     }
 
-    function _permit2TransferFromInitiator(address asset, uint256 amount) internal view returns (Call memory) {
-        return _permit2TransferFrom(asset, bundler.initiator(), amount);
-    }
-
     function _permit2TransferFrom(address asset, uint256 amount) internal view returns (Call memory) {
         return _permit2TransferFrom(asset, address(generalAdapter1), amount);
     }

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -168,6 +168,10 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
         );
     }
 
+    function _permit2TransferFromInitiator(address asset, uint256 amount) internal view returns (Call memory) {
+        return _permit2TransferFrom(asset, initiator(), amount);
+    }
+
     function _permit2TransferFrom(address asset, uint256 amount) internal view returns (Call memory) {
         return _permit2TransferFrom(asset, address(generalAdapter1), amount);
     }

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -169,7 +169,7 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
     }
 
     function _permit2TransferFromInitiator(address asset, uint256 amount) internal view returns (Call memory) {
-        return _permit2TransferFrom(asset, initiator(), amount);
+        return _permit2TransferFrom(asset, bundler.initiator(), amount);
     }
 
     function _permit2TransferFrom(address asset, uint256 amount) internal view returns (Call memory) {


### PR DESCRIPTION
Following the discussion on https://morpholabs.slack.com/archives/C02N7CZ088N/p1736176145423839, we revert upon Permit2 transfers from the `initiator` to itself.
To do so, we add a require statement on the related adapter entrypoint.
