### PR TITLE
feat: add PermissionedWrapperAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Contains the following actions, all using the paraswap aggregator:
 - Buy a given amount.
 - Buy a what's needed to fully repay on a given Morpho Market.
 
+### [`PermissionedWrapperAdapter`](./src/adapters/PermissionedWrapperAdapter.sol)
+
+Contains the following actions:
+
+- ERC20 wrap, always sends back to initiator.
+- ERC20 unwrap. Same as `GeneralAdapter1`, but this adapter can be safely whitelisted by permissioned token.
+
 ### Migration adapters
 
 For [Aave V2](./src/adapters/migration/AaveV2MigrationAdapter.sol), [Aave V3](./src/adapters/migration/AaveV3MigrationAdapter.sol), [Compound V2](./src/adapters/migration/CompoundV2MigrationAdapter.sol), [Compound V3](./src/adapters/migration/CompoundV3MigrationAdapter.sol), and [Morpho Aave V3 Optimizer](./src/adapters/migration/AaveV3OptimizerMigrationAdapter.sol).

--- a/src/adapters/GeneralAdapter1.sol
+++ b/src/adapters/GeneralAdapter1.sol
@@ -43,9 +43,7 @@ contract GeneralAdapter1 is CoreAdapter {
 
     /* ERC20 WRAPPER ACTIONS */
 
-    // Enables the wrapping and unwrapping of ERC20 tokens. The largest usecase is to wrap permissionless tokens to
-    // their permissioned counterparts and access permissioned markets on Morpho. Permissioned tokens can be built
-    // using: https://github.com/morpho-org/erc20-permissioned
+    // Enables the wrapping and unwrapping of ERC20 tokens.
 
     /// @notice Wraps underlying tokens to wrapped token.
     /// @dev Underlying tokens must have been previously sent to the adapter.

--- a/src/adapters/PermissionedWrapperAdapter.sol
+++ b/src/adapters/PermissionedWrapperAdapter.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+import {CoreAdapter, ErrorsLib, IERC20, SafeERC20} from "./CoreAdapter.sol";
+import {ERC20Wrapper} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Wrapper.sol";
+
+/// @custom:security-contact security@morpho.org
+/// @notice Permissioned wrapper adapter
+contract PermissionedWrapperAdapter is CoreAdapter {
+
+    /* CONSTRUCTOR */
+
+    /// @param bundler3 The address of the Bundler3 contract.
+    constructor(address bundler3) CoreAdapter(bundler3) {}
+
+    /* ERC20 PERMISSIONED WRAPPER ACTIONS */
+
+    // Enables the wrapping of ERC20 tokens to their permissioned counterparts.
+    // Users can then access thus access permissioned markets on Morpho.
+    // Permissioned tokens can be built using: https://github.com/morpho-org/erc20-permissioned
+
+    /// @notice Wraps underlying tokens to wrapped token and send them to the initiator.
+    /// @dev Underlying tokens must have been previously sent to the adapter.
+    /// @dev Assumes that `wrapper` implements the `ERC20Wrapper` interface.
+    /// @param wrapper The address of the ERC20 wrapper contract.
+    /// @param amount The amount of underlying tokens to deposit. Pass `type(uint).max` to deposit the adapter's
+    /// underlying balance.
+    function erc20PermissionedWrapperDeposit(address wrapper, uint256 amount) external onlyBundler3 {
+        IERC20 underlying = ERC20Wrapper(wrapper).underlying();
+        if (amount == type(uint256).max) amount = underlying.balanceOf(address(this));
+
+        require(amount != 0, ErrorsLib.ZeroAmount());
+
+        SafeERC20.forceApprove(underlying, wrapper, type(uint256).max);
+
+        require(ERC20Wrapper(wrapper).depositFor(initiator(), amount), ErrorsLib.DepositFailed());
+
+        SafeERC20.forceApprove(underlying, wrapper, 0);
+    }
+
+    /// @notice Unwraps wrapped token to underlying token.
+    /// @notice Duplicates the functionality of GeneralAdapter1.erc20WrapperWithdrawTo because permissioned tokens will not whitelist the GeneralAdapter1.
+    /// @dev Wrapped tokens must have been previously sent to the adapter.
+    /// @dev Assumes that `wrapper` implements the `ERC20Wrapper` interface.
+    /// @param wrapper The address of the ERC20 wrapper contract.
+    /// @param receiver The address receiving the underlying tokens.
+    /// @param amount The amount of wrapped tokens to burn. Pass `type(uint).max` to burn the adapter's wrapped token
+    /// balance.
+    function erc20PermissionedWrapperWithdrawTo(address wrapper, address receiver, uint256 amount) external onlyBundler3 {
+        require(receiver != address(0), ErrorsLib.ZeroAddress());
+
+        if (amount == type(uint256).max) amount = IERC20(wrapper).balanceOf(address(this));
+
+        require(amount != 0, ErrorsLib.ZeroAmount());
+
+        require(ERC20Wrapper(wrapper).withdrawTo(receiver, amount), ErrorsLib.WithdrawFailed());
+    }
+}

--- a/src/adapters/PermissionedWrapperAdapter.sol
+++ b/src/adapters/PermissionedWrapperAdapter.sol
@@ -16,7 +16,7 @@ contract PermissionedWrapperAdapter is CoreAdapter {
     /* ERC20 PERMISSIONED WRAPPER ACTIONS */
 
     // Enables the wrapping of ERC20 tokens to their permissioned counterparts.
-    // Users can then access thus access permissioned markets on Morpho.
+    // Users can then access permissioned markets on Morpho.
     // Permissioned tokens can be built using: https://github.com/morpho-org/erc20-permissioned
 
     /// @notice Wraps underlying tokens to wrapped token and send them to the initiator.

--- a/test/ERC20PermissionedWrapperAdapterLocalTest.sol
+++ b/test/ERC20PermissionedWrapperAdapterLocalTest.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ErrorsLib} from "../src/libraries/ErrorsLib.sol";
+
+import {ERC20WrapperMock, ERC20Wrapper} from "./helpers/mocks/ERC20WrapperMock.sol";
+import {ERC20PermissionedWrapperMock} from "./helpers/mocks/ERC20PermissionedWrapperMock.sol";
+
+import "./helpers/LocalTest.sol";
+
+contract ERC20PermissionedWrapperAdapterLocalTest is LocalTest {
+    ERC20WrapperMock internal wrapper;
+    ERC20PermissionedWrapperMock internal permissionedWrapper;
+
+    function setUp() public override {
+        super.setUp();
+
+        wrapper = new ERC20WrapperMock(loanToken, "Wrapped Token", "WT");
+        permissionedWrapper = new ERC20PermissionedWrapperMock(loanToken, "Permissioned Wrapped Token", "PWT");
+
+        permissionedWrapper.updateWhitelist(address(permissionedWrapperAdapter), true);
+    }
+
+    function testErc20PermissionedWrapperDeposit(uint256 amount, address initiator) public {
+        vm.assume(initiator != address(wrapper));
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        bundle.push(_erc20PermissionedWrapperDeposit(address(wrapper), amount));
+
+        deal(address(loanToken), address(permissionedWrapperAdapter), amount);
+
+        vm.prank(initiator);
+        bundler3.multicall(bundle);
+
+        assertEq(loanToken.balanceOf(address(permissionedWrapperAdapter)), 0, "loan.balanceOf(permissionedWrapperAdapter)");
+        assertEq(wrapper.balanceOf(initiator), amount, "wrapper.balanceOf(initiator)");
+        assertEq(
+            loanToken.allowance(address(permissionedWrapperAdapter), address(wrapper)),
+            0,
+            "loanToken.allowance(permissionedWrapperAdapter, wrapper)"
+        );
+    }
+
+    function testInitiatorNotWhitelistedDeposit(uint amount, address initiator) public {
+        vm.assume(initiator != address(0));
+        vm.assume(initiator != address(wrapper));
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        bundle.push(_erc20PermissionedWrapperDeposit(address(permissionedWrapper), amount));
+
+        deal(address(loanToken), address(permissionedWrapperAdapter), amount);
+
+        vm.prank(initiator);
+        vm.expectRevert("ERC20WrapperMock: non-whitelisted to address");
+        bundler3.multicall(bundle);
+    }
+
+    function testErc20PermissionedWrapperDepositZeroAmount() public {
+        bundle.push(_erc20PermissionedWrapperDeposit(address(wrapper), 0));
+
+        vm.expectRevert(ErrorsLib.ZeroAmount.selector);
+        bundler3.multicall(bundle);
+    }
+
+    function testErc20PermissionedWrapperWithdrawTo(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        deal(address(wrapper), address(permissionedWrapperAdapter), amount);
+        deal(address(loanToken), address(wrapper), amount);
+
+        bundle.push(_erc20PermissionedWrapperWithdrawTo(address(wrapper), RECEIVER, amount));
+
+        bundler3.multicall(bundle);
+
+        assertEq(wrapper.balanceOf(address(permissionedWrapperAdapter)), 0, "wrapper.balanceOf(permissionedWrapperAdapter)");
+        assertEq(loanToken.balanceOf(RECEIVER), amount, "loan.balanceOf(RECEIVER)");
+    }
+
+    function testErc20PermissionedWrapperWithdrawToAll(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        deal(address(wrapper), address(permissionedWrapperAdapter), amount);
+        deal(address(loanToken), address(wrapper), amount);
+
+        bundle.push(_erc20PermissionedWrapperWithdrawTo(address(wrapper), RECEIVER, type(uint256).max));
+
+        bundler3.multicall(bundle);
+
+        assertEq(wrapper.balanceOf(address(permissionedWrapperAdapter)), 0, "wrapper.balanceOf(permissionedWrapperAdapter)");
+        assertEq(loanToken.balanceOf(RECEIVER), amount, "loan.balanceOf(RECEIVER)");
+    }
+
+    function testErc20PermissionedWrapperWithdrawToAccountZeroAddress(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        bundle.push(_erc20PermissionedWrapperWithdrawTo(address(wrapper), address(0), amount));
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        bundler3.multicall(bundle);
+    }
+
+    function testErc20PermissionedWrapperWithdrawToZeroAmount() public {
+        bundle.push(_erc20PermissionedWrapperWithdrawTo(address(wrapper), RECEIVER, 0));
+
+        vm.expectRevert(ErrorsLib.ZeroAmount.selector);
+        bundler3.multicall(bundle);
+    }
+
+    function testErc20PermissionedWrapperDepositUnauthorized(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        vm.expectRevert(ErrorsLib.UnauthorizedSender.selector);
+        permissionedWrapperAdapter.erc20PermissionedWrapperDeposit(address(wrapper), amount);
+    }
+
+    function testErc20PermissionedWrapperWithdrawToUnauthorized(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        vm.expectRevert(ErrorsLib.UnauthorizedSender.selector);
+        permissionedWrapperAdapter.erc20PermissionedWrapperWithdrawTo(address(wrapper), RECEIVER, amount);
+    }
+
+    function testErc20PermissionedWrapperDepositToFailed(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+        deal(address(loanToken), address(permissionedWrapperAdapter), amount);
+
+        bundle.push(_erc20PermissionedWrapperDeposit(address(wrapper), amount));
+
+        vm.mockCall(address(wrapper), abi.encodeWithSelector(ERC20Wrapper.depositFor.selector), abi.encode(false));
+
+        vm.expectRevert(ErrorsLib.DepositFailed.selector);
+        bundler3.multicall(bundle);
+    }
+
+    function testErc20PermissionedWrapperWithdrawToFailed(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+        deal(address(wrapper), address(permissionedWrapperAdapter), amount);
+        deal(address(loanToken), address(wrapper), amount);
+
+        bundle.push(_erc20PermissionedWrapperWithdrawTo(address(wrapper), RECEIVER, amount));
+
+        vm.mockCall(address(wrapper), abi.encodeWithSelector(ERC20Wrapper.withdrawTo.selector), abi.encode(false));
+
+        vm.expectRevert(ErrorsLib.WithdrawFailed.selector);
+        bundler3.multicall(bundle);
+    }
+}

--- a/test/helpers/CommonTest.sol
+++ b/test/helpers/CommonTest.sol
@@ -26,6 +26,7 @@ import {IrmMock} from "../../lib/morpho-blue/src/mocks/IrmMock.sol";
 import {OracleMock} from "../../lib/morpho-blue/src/mocks/OracleMock.sol";
 import {IParaswapAdapter, Offsets} from "../../src/interfaces/IParaswapAdapter.sol";
 import {ParaswapAdapter} from "../../src/adapters/ParaswapAdapter.sol";
+import {PermissionedWrapperAdapter} from "../../src/adapters/PermissionedWrapperAdapter.sol";
 import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {Permit} from "../helpers/SigUtils.sol";
 
@@ -65,6 +66,8 @@ abstract contract CommonTest is Test {
 
     ParaswapAdapter paraswapAdapter;
 
+    PermissionedWrapperAdapter internal permissionedWrapperAdapter;
+
     AugustusRegistryMock augustusRegistryMock;
     AugustusMock augustus;
 
@@ -83,6 +86,7 @@ abstract contract CommonTest is Test {
         bundler3 = new Bundler3();
         generalAdapter1 = new GeneralAdapter1(address(bundler3), address(morpho), address(1));
         paraswapAdapter = new ParaswapAdapter(address(bundler3), address(morpho), address(augustusRegistryMock));
+        permissionedWrapperAdapter = new PermissionedWrapperAdapter(address(bundler3));
 
         irm = new IrmMock();
 
@@ -259,6 +263,24 @@ abstract contract CommonTest is Test {
         returns (Call memory)
     {
         return _call(generalAdapter1, abi.encodeCall(GeneralAdapter1.erc20WrapperWithdrawTo, (token, receiver, amount)));
+    }
+
+    /* PERMISSIONED ERC20 WRAPPER ACTIONS */
+
+    function _erc20PermissionedWrapperDeposit(address token, uint256 amount)
+        internal
+        view
+        returns (Call memory)
+    {
+        return _call(permissionedWrapperAdapter, abi.encodeCall(PermissionedWrapperAdapter.erc20PermissionedWrapperDeposit, (token, amount)));
+    }
+
+    function _erc20PermissionedWrapperWithdrawTo(address token, address receiver, uint256 amount)
+        internal
+        view
+        returns (Call memory)
+    {
+        return _call(permissionedWrapperAdapter, abi.encodeCall(PermissionedWrapperAdapter.erc20PermissionedWrapperWithdrawTo, (token, receiver, amount)));
     }
 
     /* ERC4626 ACTIONS */

--- a/test/helpers/mocks/ERC20PermissionedWrapperMock.sol
+++ b/test/helpers/mocks/ERC20PermissionedWrapperMock.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {
+    IERC20,
+    ERC20Wrapper,
+    ERC20
+} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Wrapper.sol";
+
+contract ERC20PermissionedWrapperMock is ERC20Wrapper {
+    mapping (address => bool) public whitelist;
+
+    constructor(IERC20 token, string memory _name, string memory _symbol) ERC20Wrapper(token) ERC20(_name, _symbol) {}
+
+    function _update(address from, address to, uint value) internal virtual override {
+        if (to != address(0)) {
+            if (from != address(0)) {
+                if (!whitelist[from]) {
+                    revert("ERC20WrapperMock: non-whitelisted from address");
+                }
+            }
+            if (!whitelist[to]) {
+                revert("ERC20WrapperMock: non-whitelisted to address");
+            }
+        }
+        super._update(from,to,value);
+    }
+
+    function updateWhitelist(address account, bool isWhitelisted) public {
+        whitelist[account] = isWhitelisted;
+    }
+
+}


### PR DESCRIPTION
Add `PermissionedWrapperAdapter` for permissioned tokens.

Assumes that permissioned tokens do not check `msg.sender`'s whitelist status and only consider `from` and `to`.