### PR TITLE
feat: prevent bundlerV2 erc20 transfers

### DIFF
--- a/src/adapters/BaseGeneralAdapter1.sol
+++ b/src/adapters/BaseGeneralAdapter1.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+import {IWstEth} from "../interfaces/IWstEth.sol";
+import {IStEth} from "../interfaces/IStEth.sol";
+
+import {GeneralAdapter1, CoreAdapter, ErrorsLib, SafeERC20, IERC20} from "./GeneralAdapter1.sol";
+import {ERC20Wrapper} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Wrapper.sol";
+import {MathRayLib} from "../libraries/MathRayLib.sol";
+
+/// @custom:security-contact security@morpho.org
+/// @notice Adapter contract specific to Base n°1.
+contract BaseGeneralAdapter1 is GeneralAdapter1 {
+    using MathRayLib for uint256;
+
+    /// @notice The address of the BundlerV2, to prevent unauthorized transfers.
+    address public immutable BUNDLER_V2;
+
+    /* CONSTRUCTOR */
+
+    /// @param bundler3 The address of the Bundler3 contract.
+    /// @param bundlerV2 The address of the BundlerV3 contract.
+    /// @param morpho The address of Morpho.
+    /// @param wNative The address of the canonical native token wrapper.
+    constructor(address bundler3, address bundlerV2, address morpho, address wNative)
+        GeneralAdapter1(bundler3, morpho, wNative)
+    {
+        require(bundlerV2 != address(0), ErrorsLib.ZeroAddress());
+
+        BUNDLER_V2 = bundlerV2;
+    }
+
+    /* ERC20 ACTIONS */
+
+    /// @inheritdoc CoreAdapter
+    function erc20Transfer(address token, address receiver, uint256 amount) public override onlyBundler3 {
+        require(receiver != BUNDLER_V2, ErrorsLib.ERC20TransferToBundlerV2());
+        super.erc20Transfer(token, receiver, amount);
+    }
+}

--- a/src/adapters/BaseGeneralAdapter1.sol
+++ b/src/adapters/BaseGeneralAdapter1.sol
@@ -34,7 +34,7 @@ contract BaseGeneralAdapter1 is GeneralAdapter1 {
 
     /// @inheritdoc CoreAdapter
     function erc20Transfer(address token, address receiver, uint256 amount) public override onlyBundler3 {
-        require(receiver != BUNDLER_V2, ErrorsLib.ERC20TransferToBundlerV2());
+        require(receiver != BUNDLER_V2, ErrorsLib.UnauthorizedReceiver());
         super.erc20Transfer(token, receiver, amount);
     }
 }

--- a/src/adapters/CoreAdapter.sol
+++ b/src/adapters/CoreAdapter.sol
@@ -60,7 +60,7 @@ abstract contract CoreAdapter {
     /// @param receiver The address that will receive the tokens.
     /// @param amount The amount of token to transfer. Pass `type(uint).max` to transfer the adapter's balance (this
     /// allows 0 value transfers).
-    function erc20Transfer(address token, address receiver, uint256 amount) external onlyBundler3 {
+    function erc20Transfer(address token, address receiver, uint256 amount) public virtual onlyBundler3 {
         require(receiver != address(0), ErrorsLib.ZeroAddress());
         require(receiver != address(this), ErrorsLib.AdapterAddress());
 

--- a/src/adapters/EthereumGeneralAdapter1.sol
+++ b/src/adapters/EthereumGeneralAdapter1.sol
@@ -136,7 +136,7 @@ contract EthereumGeneralAdapter1 is GeneralAdapter1 {
 
     /// @inheritdoc CoreAdapter
     function erc20Transfer(address token, address receiver, uint256 amount) public override onlyBundler3 {
-        require(receiver != BUNDLER_V2, ErrorsLib.ERC20TransferToBundlerV2());
+        require(receiver != BUNDLER_V2, ErrorsLib.UnauthorizedReceiver());
         super.erc20Transfer(token, receiver, amount);
     }
 }

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -47,7 +47,7 @@ library ErrorsLib {
     error WithdrawFailed();
 
     /// @dev Thrown when attempting an ERC20 transfer to BundlerV2.
-    error ERC20TransferToBundlerV2();
+    error UnauthorizedReceiver();
 
     /* MIGRATION ADAPTERS */
 

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -46,6 +46,9 @@ library ErrorsLib {
     /// @dev Thrown when a call to withdrawTo fails.
     error WithdrawFailed();
 
+    /// @dev Thrown when attempting an ERC20 transfer to BundlerV2.
+    error ERC20TransferToBundlerV2();
+
     /* MIGRATION ADAPTERS */
 
     /// @dev Thrown when repaying a CompoundV2 debt returns an error code.

--- a/test/ERC20WrapperAdapterLocalTest.sol
+++ b/test/ERC20WrapperAdapterLocalTest.sol
@@ -16,6 +16,28 @@ contract ERC20WrapperAdapterLocalTest is LocalTest {
         loanWrapper = new ERC20WrapperMock(loanToken, "Wrapped Loan Token", "WLT");
     }
 
+    function testERC20WrapperErc20TransferToUnauthorizedAddress(address token, uint256 amount, address receiver)
+        public
+    {
+        vm.assume(receiver != address(generalAdapter1));
+
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        bundle.push(_erc20Transfer(token, receiver, amount, erc20WrapperAdapter));
+
+        vm.expectRevert(ErrorsLib.UnauthorizedReceiver.selector);
+        bundler3.multicall(bundle);
+    }
+
+    function testERC20WrapperErc20TransferToGeneralAdapter1(uint256 amount) public {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        deal(address(loanWrapper), address(erc20WrapperAdapter), amount);
+        bundle.push(_erc20Transfer(address(loanWrapper), address(generalAdapter1), amount, erc20WrapperAdapter));
+
+        bundler3.multicall(bundle);
+    }
+
     function testErc20WrapperDepositFor(uint256 amount, address initiator) public {
         vm.assume(initiator != address(0));
         vm.assume(initiator != address(loanWrapper));

--- a/test/fork/TransferAdapterForkTest.sol
+++ b/test/fork/TransferAdapterForkTest.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
+
+import "./helpers/ForkTest.sol";
+
+contract TransferAdapterForkTest is ForkTest {
+    bool skipTest;
+
+    function setUp() public override {
+        super.setUp();
+
+        if (block.chainid != 1 && block.chainid != 8453) {
+            skipTest = true;
+        }
+    }
+
+    function testTransferToBundlerV2(address token, uint256 amount) public {
+        vm.skip(skipTest);
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        bundle.push(_erc20Transfer(token, getAddress("BUNDLER_V2"), amount, generalAdapter1));
+
+        vm.expectRevert(ErrorsLib.ERC20TransferToBundlerV2.selector);
+        bundler3.multicall(bundle);
+    }
+}

--- a/test/fork/TransferAdapterForkTest.sol
+++ b/test/fork/TransferAdapterForkTest.sol
@@ -22,7 +22,7 @@ contract TransferAdapterForkTest is ForkTest {
 
         bundle.push(_erc20Transfer(token, getAddress("BUNDLER_V2"), amount, generalAdapter1));
 
-        vm.expectRevert(ErrorsLib.ERC20TransferToBundlerV2.selector);
+        vm.expectRevert(ErrorsLib.UnauthorizedReceiver.selector);
         bundler3.multicall(bundle);
     }
 }

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -47,6 +47,9 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
         }
         paraswapAdapter = new ParaswapAdapter(address(bundler3), address(morpho), getAddress("AUGUSTUS_REGISTRY"));
 
+        // Must redeploy the ERC20WrapperAdapter to update the generalAdapter1 address.
+        erc20WrapperAdapter = new ERC20WrapperAdapter(address(bundler3), address(generalAdapter1));
+
         for (uint256 i; i < config.markets.length; ++i) {
             ConfigMarket memory configMarket = config.markets[i];
 

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -8,6 +8,7 @@ import {IAllowanceTransfer} from "../../../lib/permit2/src/interfaces/IAllowance
 import {Permit2Lib} from "../../../lib/permit2/src/libraries/Permit2Lib.sol";
 
 import {EthereumGeneralAdapter1, MathRayLib} from "../../../src/adapters/EthereumGeneralAdapter1.sol";
+import {BaseGeneralAdapter1} from "../../../src/adapters/BaseGeneralAdapter1.sol";
 
 import "./NetworkConfig.sol";
 import "../../helpers/CommonTest.sol";
@@ -31,6 +32,7 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
         if (isEq(config.network, "ethereum")) {
             ethereumGeneralAdapter1 = new EthereumGeneralAdapter1(
                 address(bundler3),
+                getAddress("BUNDLER_V2"),
                 address(morpho),
                 getAddress("WETH"),
                 getAddress("WST_ETH"),
@@ -38,8 +40,10 @@ abstract contract ForkTest is CommonTest, NetworkConfig {
                 getAddress("MORPHO_WRAPPER")
             );
             generalAdapter1 = GeneralAdapter1(ethereumGeneralAdapter1);
-        } else {
-            generalAdapter1 = new GeneralAdapter1(address(bundler3), address(morpho), getAddress("WETH"));
+        } else if (isEq(config.network, "base")) {
+            generalAdapter1 = new BaseGeneralAdapter1(
+                address(bundler3), getAddress("BUNDLER_V2"), address(morpho), getAddress("WETH")
+            );
         }
         paraswapAdapter = new ParaswapAdapter(address(bundler3), address(morpho), getAddress("AUGUSTUS_REGISTRY"));
 

--- a/test/fork/helpers/NetworkConfig.sol
+++ b/test/fork/helpers/NetworkConfig.sol
@@ -56,6 +56,7 @@ abstract contract NetworkConfig is CommonBase {
             setAddress("AUGUSTUS_V6_2", 0x6A000F20005980200259B80c5102003040001068);
             setAddress("AUGUSTUS_REGISTRY", 0xa68bEA62Dc4034A689AA0F58A76681433caCa663);
             setAddress("WBIB01", 0xcA2A7068e551d5C4482eb34880b194E4b945712F);
+            setAddress("BUNDLER_V2", 0x4095F064B8d3c3548A3bebfd0Bbfd04750E30077);
 
             /* BASE NETWORK */
         } else if (config.chainid == 8453) {
@@ -72,6 +73,7 @@ abstract contract NetworkConfig is CommonBase {
             setAddress("AUGUSTUS_V6_2", 0x6A000F20005980200259B80c5102003040001068);
             setAddress("AUGUSTUS_REGISTRY", 0x7E31B336F9E8bA52ba3c4ac861b033Ba90900bb3);
             setAddress("VER_USDC", 0x59aaF835D34b1E3dF2170e4872B785f11E2a964b);
+            setAddress("BUNDLER_V2", 0x23055618898e202386e6c13955a58D3C68200BFB);
         }
     }
 

--- a/test/helpers/CommonTest.sol
+++ b/test/helpers/CommonTest.sol
@@ -84,7 +84,7 @@ abstract contract CommonTest is Test {
 
         bundler3 = new Bundler3();
         generalAdapter1 = new GeneralAdapter1(address(bundler3), address(morpho), address(1));
-        erc20WrapperAdapter = new ERC20WrapperAdapter(address(bundler3));
+        erc20WrapperAdapter = new ERC20WrapperAdapter(address(bundler3), address(generalAdapter1));
         paraswapAdapter = new ParaswapAdapter(address(bundler3), address(morpho), address(augustusRegistryMock));
 
         irm = new IrmMock();


### PR DESCRIPTION
Prevent transfer to BundlerV2 to prevent unauthorized unwrapping. Also prevents `ERC20WrapperAdapter` from sending to other contracts than GeneralAdapter1.

Note that other functions with `receiver` arguments should be checked: it should not be possible to use those functions to send tokens to BundlerV2 without going through a whitelisted address.