### PR TITLE
[Certora] Call resolution problem

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -16,6 +16,7 @@ jobs:
 
       matrix:
         conf:
+          - CallResolution
           - AllowancesInvariant
           - Bundler3
           - GeneralAdapter1Reverts

--- a/certora/confs/CallResolution.conf
+++ b/certora/confs/CallResolution.conf
@@ -1,0 +1,12 @@
+{
+  "files": [
+    // Add a contract with the function approve in the scenery.
+    "test/helpers/mocks/ERC20Mock.sol",
+    "certora/dispatch/CallResolution.sol"
+  ],
+  "solc": "solc-0.8.28",
+  "verify": "CallResolution:certora/specs/CallResolution.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Call Resolution Problem",
+}

--- a/certora/dispatch/CallResolution.sol
+++ b/certora/dispatch/CallResolution.sol
@@ -1,0 +1,17 @@
+import {IERC20} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+
+contract CallResolution {
+    address target;
+
+    constructor(address _target) {
+        target = _target;
+    }
+
+    function doUnresolvedCall(bytes calldata data) external returns (bytes memory) {
+        // Calls to approve are not allowed, summarization aren not expected to be resolvable.
+        require(bytes4(msg.data[:4]) != IERC20.approve.selector);
+        (bool success, bytes memory x) = address(target).call(data);
+        require(success);
+        return x;
+    }
+}

--- a/certora/dispatch/CallResolution.sol
+++ b/certora/dispatch/CallResolution.sol
@@ -9,7 +9,7 @@ contract CallResolution {
 
     function doUnresolvedCall(bytes calldata data) external returns (bytes memory) {
         // Calls to approve are not allowed, summarization aren not expected to be resolvable.
-        require(bytes4(msg.data[:4]) != IERC20.approve.selector);
+        require(bytes4(data[:4]) != IERC20.approve.selector);
         (bool success, bytes memory x) = address(target).call(data);
         require(success);
         return x;

--- a/certora/specs/CallResolution.spec
+++ b/certora/specs/CallResolution.spec
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+methods {
+    // The unresolved call should not to be reachable.
+    function _.approve(address spender, uint256 amount) external => ASSERT_FALSE;
+
+    // Force call resolution to reach the ASSERT_FALSE summary introduced before.
+    unresolved external in currentContract.doUnresolvedCall(bytes) => DISPATCH [ _.approve(address, uint256) ] default NONDET;
+}
+
+rule canSummarize(env e, bytes data){
+
+    doUnresolvedCall@withrevert(e, data);
+    // The verification should reach the ASSERT_FALSE summary and fail.
+
+    // Dummy non trivial goal.
+    satisfy !lastReverted;
+}


### PR DESCRIPTION
This draft PR:
  - showcase the call resolution problem where a forbidden call still gets resolved even though it should not;
  - the target call should reach an assert false, we attempt to provide hints to reach it however, the verification goes through instead of failing;
  - this could be used to improve the spec of Paraswap related to trusting the Augustus contract and its approvals.

You can check the outcome here : https://github.com/morpho-org/bundler3/actions/runs/13725079449/job/38389473996?pr=253